### PR TITLE
Upgrade to Zendesk 2.6.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,5 +48,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "zendesk.messaging:messaging-android:2.5.0"
+    implementation "zendesk.messaging:messaging-android:2.6.0"
 }

--- a/ios/zendesk_messaging.podspec
+++ b/ios/zendesk_messaging.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ZendeskSDKMessaging', '~>2.5.0'
+  s.dependency 'ZendeskSDKMessaging', '2.4.1'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/zendesk_messaging.podspec
+++ b/ios/zendesk_messaging.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'zendesk_messaging'
-  s.version          = '0.0.1'
+  s.version          = '2.6.0'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ZendeskSDKMessaging', '2.4.1'
+  s.dependency 'ZendeskSDKMessaging', '2.6.0'
   s.platform = :ios, '10.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -148,14 +148,21 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zendesk_messaging
 description: Zendesk-Messaging for Flutter developer
-version: 0.0.3
+version: 2.6.0
 homepage: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging
 
 environment:

--- a/zendesk_messaging.iml
+++ b/zendesk_messaging.iml
@@ -11,6 +11,9 @@
       <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/example/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/zendesk_messaging/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/zendesk_messaging/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/zendesk_messaging/.pub" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />


### PR DESCRIPTION
Hi @chyiiiiiiiiiiii ,

This PR upgrade the project to 2.6.0.

I changed the version number to match the Zendesk version (easier to understand). There is a previous commit with a rollback due to incompatibilities which seems to be fixed in 2.6.0.

Could you create a new version on pubdev with tag=2.6.0 ?

Thanks for your review !