### PR TITLE
Add unread message count to lib 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There's must be a logged user to allow the recovery of the unread message count!
 
 ```dart
 // Retrieve the unread message count
-final int count = await await ZendeskMessaging.messageCount();
+final int count = await ZendeskMessaging.getUnreadMessageCount()();
 
 // if there's no user logged in, the message count will always be zero.
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ await ZendeskMessaging.logoutUser();
 await ZendeskMessaging.loginUserCallbacks(jwt: "YOUR_JWT", onSuccess: (id, externalId) => ..., onFailure: () => ...;
 await ZendeskMessaging.logoutUserCallbacks(onSuccess: () => ..., onFailure: () => ...);
 ```
+### Retrieve the unread message count (optional)
+
+There's must be a logged user to allow the recovery of the unread message count!
+
+```dart
+// Retrieve the unread message count
+final int count = await await ZendeskMessaging.messageCount();
+
+// if there's no user logged in, the message count will always be zero.
+```
 
 ### Global observer (optional)
 

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -20,7 +20,6 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         const val loginFailure: String = "login_failure"
         const val logoutSuccess: String = "logout_success"
         const val logoutFailure: String = "logout_failure"
-        const val messageCount: String = "message_count"
     }
 
     fun initialize(channelKey: String) {
@@ -46,9 +45,12 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         Zendesk.instance.messaging.showMessaging(plugin.activity!!, Intent.FLAG_ACTIVITY_NEW_TASK)
         println("$tag - show")
     }
-    fun countMessages(){
-       val count =  Zendesk.instance.messaging.getUnreadMessageCount()
-        channel.invokeMethod(messageCount,count)
+    fun countMessages(): Int {
+        return try {
+            Zendesk.instance.messaging.getUnreadMessageCount()
+        }catch (error: Throwable){
+            0
+        }
     }
 
     fun loginUser(jwt: String) {

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -7,7 +7,10 @@ import kotlinx.coroutines.launch
 import zendesk.android.Zendesk
 import zendesk.android.ZendeskResult
 import zendesk.android.ZendeskUser
+import zendesk.android.events.ZendeskEvent
+import zendesk.android.events.ZendeskEventListener
 import zendesk.messaging.android.DefaultMessagingFactory
+
 
 class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val channel: MethodChannel) {
     companion object {
@@ -20,6 +23,30 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         const val loginFailure: String = "login_failure"
         const val logoutSuccess: String = "logout_success"
         const val logoutFailure: String = "logout_failure"
+        const val incomingMessage: String = "incoming_message"
+    }
+
+    private val zendeskEventListener: ZendeskEventListener = ZendeskEventListener {
+        zendeskEvent -> when (zendeskEvent) {
+        is ZendeskEvent.UnreadMessageCountChanged ->{
+           if(zendeskEvent.currentUnreadCount!=0){
+               channel.invokeMethod(incomingMessage,zendeskEvent.currentUnreadCount)
+           }
+        }
+        is ZendeskEvent.AuthenticationFailed -> {
+            println(zendeskEvent.error.message)
+        }
+        else -> {
+            println(zendeskEvent.toString())
+        }
+    }
+    }
+
+    fun addEventListener() {
+        Zendesk.instance.addEventListener(zendeskEventListener)
+    }
+    fun removeEventListener() {
+        Zendesk.instance.removeEventListener(zendeskEventListener)
     }
 
     fun initialize(channelKey: String) {
@@ -86,3 +113,5 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         }
     }
 }
+
+

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -23,31 +23,8 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         const val loginFailure: String = "login_failure"
         const val logoutSuccess: String = "logout_success"
         const val logoutFailure: String = "logout_failure"
-        const val incomingMessage: String = "incoming_message"
     }
 
-    private val zendeskEventListener: ZendeskEventListener = ZendeskEventListener {
-        zendeskEvent -> when (zendeskEvent) {
-        is ZendeskEvent.UnreadMessageCountChanged ->{
-           if(zendeskEvent.currentUnreadCount!=0){
-               channel.invokeMethod(incomingMessage,zendeskEvent.currentUnreadCount)
-           }
-        }
-        is ZendeskEvent.AuthenticationFailed -> {
-            println(zendeskEvent.error.message)
-        }
-        else -> {
-            println(zendeskEvent.toString())
-        }
-    }
-    }
-
-    fun addEventListener() {
-        Zendesk.instance.addEventListener(zendeskEventListener)
-    }
-    fun removeEventListener() {
-        Zendesk.instance.removeEventListener(zendeskEventListener)
-    }
 
     fun initialize(channelKey: String) {
         println("$tag - Channel Key - $channelKey")

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -7,8 +7,6 @@ import kotlinx.coroutines.launch
 import zendesk.android.Zendesk
 import zendesk.android.ZendeskResult
 import zendesk.android.ZendeskUser
-import zendesk.android.events.ZendeskEvent
-import zendesk.android.events.ZendeskEventListener
 import zendesk.messaging.android.DefaultMessagingFactory
 
 
@@ -32,12 +30,12 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
             plugin.activity!!,
             channelKey,
             successCallback = { value ->
-                plugin.isInitialize = true;
+                plugin.isInitialized = true;
                 println("$tag - initialize success - $value")
                 channel.invokeMethod(initializeSuccess, null)
             },
             failureCallback = { error ->
-                plugin.isInitialize = false;
+                plugin.isInitialized = false;
                 println("$tag - initialize failure - $error")
                 channel.invokeMethod(initializeFailure, mapOf("error" to error.message))
             },
@@ -49,7 +47,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         Zendesk.instance.messaging.showMessaging(plugin.activity!!, Intent.FLAG_ACTIVITY_NEW_TASK)
         println("$tag - show")
     }
-    fun countMessages(): Int {
+    fun getUnreadMessageCount(): Int {
         return try {
             Zendesk.instance.messaging.getUnreadMessageCount()
         }catch (error: Throwable){

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -20,6 +20,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         const val loginFailure: String = "login_failure"
         const val logoutSuccess: String = "logout_success"
         const val logoutFailure: String = "logout_failure"
+        const val messageCount: String = "message_count"
     }
 
     fun initialize(channelKey: String) {
@@ -44,6 +45,10 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
     fun show() {
         Zendesk.instance.messaging.showMessaging(plugin.activity!!, Intent.FLAG_ACTIVITY_NEW_TASK)
         println("$tag - show")
+    }
+    fun countMessages(){
+       val count =  Zendesk.instance.messaging.getUnreadMessageCount()
+        channel.invokeMethod(messageCount,count)
     }
 
     fun loginUser(jwt: String) {

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -72,7 +72,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     println("$tag - Messaging needs to be initialized first")
                     return
                 }
-                zendeskMessaging.countMessages()
+                result.success(zendeskMessaging.countMessages())
             }
             else -> {
                 result.notImplemented()

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -9,7 +9,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-
 /** ZendeskMessagingPlugin */
 class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     /// The MethodChannel that will the communication between Flutter and native Android
@@ -21,7 +20,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     var activity: Activity? = null
     var isInitialized: Boolean = false
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
         val sendData: Any? = call.arguments
         val zendeskMessaging = ZendeskMessaging(this, channel)
 

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -9,7 +9,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.MethodChannel.Result
 
 /** ZendeskMessagingPlugin */
 class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
@@ -20,7 +19,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private val tag = "[ZendeskMessagingPlugin]"
     private lateinit var channel: MethodChannel
     var activity: Activity? = null
-    var isInitialize: Boolean = false
+    var isInitialized: Boolean = false
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         val sendData: Any? = call.arguments
@@ -28,7 +27,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
         when (call.method) {
             "initialize" -> {
-                if (isInitialize) {
+                if (isInitialized) {
                     println("$tag - Messaging is already initialized!")
                     return
                 }
@@ -36,17 +35,17 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 zendeskMessaging.initialize(channelKey)
             }
             "show" -> {
-                if (!isInitialize) {
+                if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
                     return
                 }
                 zendeskMessaging.show()
             }
             "isInitialized" -> {
-                result.success(isInitialize)
+                result.success(isInitialized)
             }
             "loginUser" -> {
-                if (!isInitialize) {
+                if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
                     return
                 }
@@ -64,18 +63,18 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
             }
             "logoutUser" -> {
-                if (!isInitialize) {
+                if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
                     return
                 }
                 zendeskMessaging.logoutUser()
             }
-            "countMessages" -> {
-                if (!isInitialize) {
+            "getUnreadMessageCount" -> {
+                if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
                     return
                 }
-                result.success(zendeskMessaging.countMessages())
+                result.success(zendeskMessaging.getUnreadMessageCount())
             }
             else -> {
                 result.notImplemented()

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -67,6 +67,13 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 zendeskMessaging.logoutUser()
             }
+            "countMessages" -> {
+                if (!isInitialize) {
+                    println("$tag - Messaging needs to be initialized first")
+                    return
+                }
+                zendeskMessaging.countMessages()
+            }
             else -> {
                 result.notImplemented()
             }

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -42,6 +42,9 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 zendeskMessaging.show()
             }
+            "isInitialized" -> {
+                result.success(isInitialize)
+            }
             "loginUser" -> {
                 if (!isInitialize) {
                     println("$tag - Messaging needs to be initialized first")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,11 +13,13 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  static const String androidChannelKey = "eyJzZXR0aW5nc191cmwiOiJodHRwczovL2hhbmFtaWhlbHAuemVuZGVzay5jb20vbW9iaWxlX3Nka19hcGkvc2V0dGluZ3MvMDFGR0tDRTlSNEFLWDBGOUc2Sk04Mk5RQU0uanNvbiJ9";
-  static const String iosChannelKey = "eyJzZXR0aW5nc191cmwiOiJodHRwczovL2hhbmFtaWhlbHAuemVuZGVzay5jb20vbW9iaWxlX3Nka19hcGkvc2V0dGluZ3MvMDFGR1BGVFQ1Q1hFRjdRWVkwUkg2R0JYS0MuanNvbiJ9";
+  static const String androidChannelKey =
+      "eyJzZXR0aW5nc191cmwiOiJodHRwczovL2hhbmFtaWhlbHAuemVuZGVzay5jb20vbW9iaWxlX3Nka19hcGkvc2V0dGluZ3MvMDFGR0tDRTlSNEFLWDBGOUc2Sk04Mk5RQU0uanNvbiJ9";
+  static const String iosChannelKey =
+      "eyJzZXR0aW5nc191cmwiOiJodHRwczovL2hhbmFtaWhlbHAuemVuZGVzay5jb20vbW9iaWxlX3Nka19hcGkvc2V0dGluZ3MvMDFGR1BGVFQ1Q1hFRjdRWVkwUkg2R0JYS0MuanNvbiJ9";
 
   final List<String> channelMessages = [];
-  int unreadMessageCount =0;
+  int unreadMessageCount = 0;
 
   @override
   void initState() {
@@ -45,16 +47,26 @@ class _MyAppState extends State<MyApp> {
             child: ListView(
               children: [
                 Text(message),
-               const SizedBox(height: 20,),
-
+                const SizedBox(
+                  height: 20,
+                ),
                 ElevatedButton(
-                  onPressed: () => ZendeskMessaging.initialize(androidChannelKey: androidChannelKey, iosChannelKey: iosChannelKey),
+                  onPressed: () => ZendeskMessaging.initialize(
+                      androidChannelKey: androidChannelKey,
+                      iosChannelKey: iosChannelKey),
                   child: const Text("Initialize"),
                 ),
-                ElevatedButton(onPressed: () => ZendeskMessaging.show(), child: const Text("Show messaging")),
-                ElevatedButton(onPressed: () => countMessages(), child: const Text("Count unread messages")),
-                ElevatedButton(onPressed: () => _login(), child: const Text("Login")),
-                ElevatedButton(onPressed: () => ZendeskMessaging.logoutUser(), child: const Text("Logout")),
+                ElevatedButton(
+                    onPressed: () => ZendeskMessaging.show(),
+                    child: const Text("Show messaging")),
+                ElevatedButton(
+                    onPressed: () => countMessages(),
+                    child: const Text("Count unread messages")),
+                ElevatedButton(
+                    onPressed: () => _login(), child: const Text("Login")),
+                ElevatedButton(
+                    onPressed: () => ZendeskMessaging.logoutUser(),
+                    child: const Text("Logout")),
               ],
             ),
           ),
@@ -67,12 +79,15 @@ class _MyAppState extends State<MyApp> {
     // You can attach local observer when calling some methods to be notified when ready
     ZendeskMessaging.loginUserCallbacks(
       jwt: "my_jwt",
-      onSuccess: (id, externalId) => setState(() => channelMessages.add("Login observer SUCCESS: $id, $externalId")),
-      onFailure: () => setState(() => channelMessages.add("Login observer FAILURE !")),
+      onSuccess: (id, externalId) => setState(() =>
+          channelMessages.add("Login observer SUCCESS: $id, $externalId")),
+      onFailure: () =>
+          setState(() => channelMessages.add("Login observer FAILURE !")),
     );
   }
-  void countMessages()async{
-    final messageCount = await ZendeskMessaging.messageCount();
+
+  void countMessages() async {
+    final messageCount = await ZendeskMessaging.getUnreadMessageCount();
     setState(() {
       unreadMessageCount = messageCount;
     });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,7 @@ class _MyAppState extends State<MyApp> {
                     onPressed: () => ZendeskMessaging.show(),
                     child: const Text("Show messaging")),
                 ElevatedButton(
-                    onPressed: () => countMessages(),
+                    onPressed: () => _getUnreadMessageCount(),
                     child: const Text("Count unread messages")),
                 ElevatedButton(
                     onPressed: () => _login(), child: const Text("Login")),
@@ -86,7 +86,7 @@ class _MyAppState extends State<MyApp> {
     );
   }
 
-  void countMessages() async {
+  void _getUnreadMessageCount() async {
     final messageCount = await ZendeskMessaging.getUnreadMessageCount();
     setState(() {
       unreadMessageCount = messageCount;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,6 +17,7 @@ class _MyAppState extends State<MyApp> {
   static const String iosChannelKey = "eyJzZXR0aW5nc191cmwiOiJodHRwczovL2hhbmFtaWhlbHAuemVuZGVzay5jb20vbW9iaWxlX3Nka19hcGkvc2V0dGluZ3MvMDFGR1BGVFQ1Q1hFRjdRWVkwUkg2R0JYS0MuanNvbiJ9";
 
   final List<String> channelMessages = [];
+  int unreadMessageCount =0;
 
   @override
   void initState() {
@@ -44,11 +45,14 @@ class _MyAppState extends State<MyApp> {
             child: ListView(
               children: [
                 Text(message),
+               const SizedBox(height: 20,),
+
                 ElevatedButton(
                   onPressed: () => ZendeskMessaging.initialize(androidChannelKey: androidChannelKey, iosChannelKey: iosChannelKey),
                   child: const Text("Initialize"),
                 ),
                 ElevatedButton(onPressed: () => ZendeskMessaging.show(), child: const Text("Show messaging")),
+                ElevatedButton(onPressed: () => countMessages(), child: const Text("Count unread messages")),
                 ElevatedButton(onPressed: () => _login(), child: const Text("Login")),
                 ElevatedButton(onPressed: () => ZendeskMessaging.logoutUser(), child: const Text("Logout")),
               ],
@@ -66,5 +70,11 @@ class _MyAppState extends State<MyApp> {
       onSuccess: (id, externalId) => setState(() => channelMessages.add("Login observer SUCCESS: $id, $externalId")),
       onFailure: () => setState(() => channelMessages.add("Login observer FAILURE !")),
     );
+  }
+  void countMessages()async{
+    final messageCount = await ZendeskMessaging.messageCount();
+    setState(() {
+      unreadMessageCount = messageCount;
+    });
   }
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/main.dart';
+import 'package:zendesk_messaging_example/main.dart';
 
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -4,7 +4,7 @@ import UIKit
 public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     let TAG = "[SwiftZendeskMessagingPlugin]"
     private var channel: FlutterMethodChannel
-    var isInitialize = false
+    var isInitialized = false
     
     init(channel: FlutterMethodChannel) {
         self.channel = channel
@@ -25,7 +25,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
         // chat sdk method channels
         switch(method){
             case "initialize":
-                if (isInitialize) {
+                if (isInitialized) {
                     print("\(TAG) - Messaging is already initialize!\n")
                     return
                 }
@@ -33,26 +33,26 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 zendeskMessaging.initialize(channelKey: channelKey)
                 break;
             case "show":
-                if (!isInitialize) {
+                if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController)
                 break
             case "loginUser":
-                if (!isInitialize) {
+                if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 let jwt: String = arguments?["jwt"] as! String
                 zendeskMessaging.loginUser(jwt: jwt)
                 break
             case "logoutUser":
-                if (!isInitialize) {
+                if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.logoutUser()
                 break
             case "getUnreadMessageCount":
-                if (!isInitialize) {
+                if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 result(handleMessageCount())
@@ -74,6 +74,6 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
         return zendeskMessaging.getUnreadMessageCount()
     }
     private func handleInitializedStatus() ->Bool{
-        return isInitialize
+        return isInitialized
     }
 }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -51,10 +51,27 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 zendeskMessaging.logoutUser()
                 break
+            case "countMessages":
+                if (!isInitialize) {
+                    print("\(TAG) - Messaging needs to be initialized first.\n")
+                }
+            handleMessageCount()
+            break
+            
+            case "isInitialized":
+            handleInitializedStatus()
+            break
             default:
                 break
         }
 
         result(nil)
+    }
+
+    private func handleMessageCount() ->Int{
+        return zendeskMessaging.countMessages()
+    }
+    private func handleInitializedStatus() ->Bool{
+        return isInitialize
     }
 }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -55,12 +55,12 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 if (!isInitialize) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
-            handleMessageCount()
-            break
+                result(handleMessageCount())
+                break
             
             case "isInitialized":
-            handleInitializedStatus()
-            break
+                result(handleInitializedStatus())
+                break
             default:
                 break
         }
@@ -69,6 +69,8 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     }
 
     private func handleMessageCount() ->Int{
+         let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
+
         return zendeskMessaging.countMessages()
     }
     private func handleInitializedStatus() ->Bool{

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -51,7 +51,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 zendeskMessaging.logoutUser()
                 break
-            case "countMessages":
+            case "getUnreadMessageCount":
                 if (!isInitialize) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
@@ -71,7 +71,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     private func handleMessageCount() ->Int{
          let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
 
-        return zendeskMessaging.countMessages()
+        return zendeskMessaging.getUnreadMessageCount()
     }
     private func handleInitializedStatus() ->Bool{
         return isInitialize

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -24,11 +24,11 @@ public class ZendeskMessaging: NSObject {
         print("\(self.TAG) - Channel Key - \(channelKey)\n")
         Zendesk.initialize(withChannelKey: channelKey, messagingFactory: DefaultMessagingFactory()) { result in
             if case let .failure(error) = result {
-                self.zendeskPlugin?.isInitialize = false
+                self.zendeskPlugin?.isInitialized = false
                 print("\(self.TAG) - initialize failure - \(error.localizedDescription)\n")
                 self.channel?.invokeMethod(ZendeskMessaging.initializeFailure, arguments: ["error": error.localizedDescription])
             } else {
-                self.zendeskPlugin?.isInitialize = true
+                self.zendeskPlugin?.isInitialized = true
                 print("\(self.TAG) - initialize success")
                 self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [])
             }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -69,7 +69,7 @@ public class ZendeskMessaging: NSObject {
             }
         }
     }
-    func countMessages() -> Int {
+    func getUnreadMessageCount() -> Int {
         let count = Zendesk.instance?.messaging?.getUnreadMessageCount()
         return count ?? 0
     }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -69,4 +69,7 @@ public class ZendeskMessaging: NSObject {
             }
         }
     }
+    func countMessages() -> Int {
+        return Zendesk.instance?.messaging?.getUnreadMessageCount()
+    }
 }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -70,6 +70,7 @@ public class ZendeskMessaging: NSObject {
         }
     }
     func countMessages() -> Int {
-        return Zendesk.instance?.messaging?.getUnreadMessageCount()
+        let count = Zendesk.instance?.messaging?.getUnreadMessageCount()
+        return count ?? 0
     }
 }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -162,15 +162,14 @@ class ZendeskMessaging {
     return completer.future;
   }
 
-  static Future<void> messageCount() async {
+  static Future<int> messageCount() async {
     try {
-      await _channel.invokeMethod(
+      return await _channel.invokeMethod(
         'countMessages',
       );
-      return;
     } catch (e) {
       debugPrint('ZendeskMessaging - count - Error: $e}');
-      return;
+      return 0;
     }
   }
 

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -12,7 +12,6 @@ enum ZendeskMessagingMessageType {
   loginFailure,
   logoutSuccess,
   logoutFailure,
-  incomingMessage,
 }
 
 /// Used by ZendeskMessaging to attach custom async observers
@@ -39,7 +38,6 @@ class ZendeskMessaging {
     "login_failure": ZendeskMessagingMessageType.loginFailure,
     "logout_success": ZendeskMessagingMessageType.logoutSuccess,
     "logout_failure": ZendeskMessagingMessageType.logoutFailure,
-    "incoming_message": ZendeskMessagingMessageType.incomingMessage,
   };
 
   /// Global handler, all channel method calls will trigger this observer
@@ -65,8 +63,6 @@ class ZendeskMessaging {
 
     try {
       _channel.setMethodCallHandler(_onMethodCall); // start observing channel messages
-      _setObserver(ZendeskMessagingMessageType.incomingMessage, (args) {
-      });
       await _channel.invokeMethod('initialize', {
         'channelKey': Platform.isAndroid ? androidChannelKey : iosChannelKey,
       });
@@ -153,7 +149,7 @@ class ZendeskMessaging {
         'countMessages',
       );
     } catch (e) {
-      debugPrint('ZendeskMessaging - isInitialized - Error: $e}');
+      debugPrint('ZendeskMessaging - count - Error: $e}');
       return 0;
     }
   }
@@ -164,7 +160,7 @@ class ZendeskMessaging {
         'isInitialized',
       );
     } catch (e) {
-      debugPrint('ZendeskMessaging - count - Error: $e}');
+      debugPrint('ZendeskMessaging - isInitialized - Error: $e}');
       return false;
     }
   }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -12,6 +12,7 @@ enum ZendeskMessagingMessageType {
   loginFailure,
   logoutSuccess,
   logoutFailure,
+  messageCount,
 }
 
 /// Used by ZendeskMessaging to attach custom async observers
@@ -38,16 +39,19 @@ class ZendeskMessaging {
     "login_failure": ZendeskMessagingMessageType.loginFailure,
     "logout_success": ZendeskMessagingMessageType.logoutSuccess,
     "logout_failure": ZendeskMessagingMessageType.logoutFailure,
+    "message_count": ZendeskMessagingMessageType.messageCount,
   };
 
   /// Global handler, all channel method calls will trigger this observer
   static Function(ZendeskMessagingMessageType type, Map? arguments)? _handler;
 
   /// Allow end-user to use local observer when calling some methods
-  static final Map<ZendeskMessagingMessageType, ZendeskMessagingObserver> _observers = {};
+  static final Map<ZendeskMessagingMessageType, ZendeskMessagingObserver>
+      _observers = {};
 
   /// Attach a global observer for incoming messages
-  static void setMessageHandler(Function(ZendeskMessagingMessageType type, Map? arguments)? handler) {
+  static void setMessageHandler(
+      Function(ZendeskMessagingMessageType type, Map? arguments)? handler) {
     _handler = handler;
   }
 
@@ -55,14 +59,17 @@ class ZendeskMessaging {
   ///
   /// @param  androidChannelKey  The Android SDK key generated from Zendesk dashboard
   /// @param  iosChannelKey      The iOS SDK key generated from the Zendesk dashboard
-  static Future<void> initialize({required String androidChannelKey, required String iosChannelKey}) async {
+  static Future<void> initialize(
+      {required String androidChannelKey,
+      required String iosChannelKey}) async {
     if (androidChannelKey.isEmpty || iosChannelKey.isEmpty) {
       debugPrint('ZendeskMessaging - initialize - keys can not be empty');
       return;
     }
 
     try {
-      _channel.setMethodCallHandler(_onMethodCall); // start observing channel messages
+      _channel.setMethodCallHandler(
+          _onMethodCall); // start observing channel messages
       await _channel.invokeMethod('initialize', {
         'channelKey': Platform.isAndroid ? androidChannelKey : iosChannelKey,
       });
@@ -87,15 +94,23 @@ class ZendeskMessaging {
   /// @param  jwt       Required by the SDK - You must generate it from your backend
   /// @param  onSuccess Optional - If you need to be notified about the login success
   /// @param  onFailure Optional - If you need to be notified about the login failure
-  static Future<void> loginUserCallbacks({required String jwt, Function(String? id, String? externalId)? onSuccess, Function()? onFailure}) async {
+  static Future<void> loginUserCallbacks(
+      {required String jwt,
+      Function(String? id, String? externalId)? onSuccess,
+      Function()? onFailure}) async {
     if (jwt.isEmpty) {
       debugPrint('ZendeskMessaging - loginUser - jwt can not be empty');
       return;
     }
 
     try {
-      _setObserver(ZendeskMessagingMessageType.loginSuccess, onSuccess != null ? (Map? args) => onSuccess(args?["id"], args?["externalId"]) : null);
-      _setObserver(ZendeskMessagingMessageType.loginFailure, onFailure != null ? (Map? args) => onFailure() : null);
+      _setObserver(
+          ZendeskMessagingMessageType.loginSuccess,
+          onSuccess != null
+              ? (Map? args) => onSuccess(args?["id"], args?["externalId"])
+              : null);
+      _setObserver(ZendeskMessagingMessageType.loginFailure,
+          onFailure != null ? (Map? args) => onFailure() : null);
 
       await _channel.invokeMethod('loginUser', {'jwt': jwt});
     } catch (e) {
@@ -110,8 +125,10 @@ class ZendeskMessaging {
     var completer = Completer<ZendeskLoginResponse>();
     await loginUserCallbacks(
       jwt: jwt,
-      onSuccess: (id, externalId) => completer.complete(ZendeskLoginResponse(id, externalId)),
-      onFailure: () => completer.completeError(Exception("Zendesk::loginUser failed")),
+      onSuccess: (id, externalId) =>
+          completer.complete(ZendeskLoginResponse(id, externalId)),
+      onFailure: () =>
+          completer.completeError(Exception("Zendesk::loginUser failed")),
     );
     return completer.future;
   }
@@ -120,10 +137,13 @@ class ZendeskMessaging {
   ///
   /// @param  onSuccess Optional - If you need to be notified about the logout success
   /// @param  onFailure Optional - If you need to be notified about the logout failure
-  static Future<void> logoutUserCallbacks({Function()? onSuccess, Function()? onFailure}) async {
+  static Future<void> logoutUserCallbacks(
+      {Function()? onSuccess, Function()? onFailure}) async {
     try {
-      _setObserver(ZendeskMessagingMessageType.logoutSuccess, onSuccess != null ? (Map? args) => onSuccess() : null);
-      _setObserver(ZendeskMessagingMessageType.logoutFailure, onFailure != null ? (Map? args) => onFailure() : null);
+      _setObserver(ZendeskMessagingMessageType.logoutSuccess,
+          onSuccess != null ? (Map? args) => onSuccess() : null);
+      _setObserver(ZendeskMessagingMessageType.logoutFailure,
+          onFailure != null ? (Map? args) => onFailure() : null);
 
       await _channel.invokeMethod('logoutUser');
     } catch (e) {
@@ -136,9 +156,22 @@ class ZendeskMessaging {
     var completer = Completer<void>();
     await logoutUserCallbacks(
       onSuccess: () => completer.complete(),
-      onFailure: () => completer.completeError(Exception("Zendesk::logoutUser failed")),
+      onFailure: () =>
+          completer.completeError(Exception("Zendesk::logoutUser failed")),
     );
     return completer.future;
+  }
+
+  static Future<void> messageCount() async {
+    try {
+      await _channel.invokeMethod(
+        'countMessages',
+      );
+      return;
+    } catch (e) {
+      debugPrint('ZendeskMessaging - count - Error: $e}');
+      return;
+    }
   }
 
   /// Handle incoming message from platforms (iOS and Android)
@@ -147,7 +180,8 @@ class ZendeskMessaging {
       return;
     }
 
-    final ZendeskMessagingMessageType type = channelMethodToMessageType[call.method]!;
+    final ZendeskMessagingMessageType type =
+        channelMethodToMessageType[call.method]!;
     var globalHandler = _handler;
     if (globalHandler != null) {
       globalHandler(type, call.arguments);
@@ -164,7 +198,9 @@ class ZendeskMessaging {
   }
 
   /// Add an observer for a specific type
-  static _setObserver(ZendeskMessagingMessageType type, Function(Map? args)? func, {bool removeOnCall = true}) {
+  static _setObserver(
+      ZendeskMessagingMessageType type, Function(Map? args)? func,
+      {bool removeOnCall = true}) {
     if (func == null) {
       _observers.remove(type);
     } else {

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -144,10 +144,10 @@ class ZendeskMessaging {
   }
 
   /// Retrieve uread messages count from the Zendesk SDK
-  static Future<int> messageCount() async {
+  static Future<int> getUnreadMessageCount() async {
     try {
       return await _channel.invokeMethod(
-        'countMessages',
+        'getUnreadMessageCount',
       );
     } catch (e) {
       debugPrint('ZendeskMessaging - count - Error: $e}');

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -143,6 +143,7 @@ class ZendeskMessaging {
     return completer.future;
   }
 
+  /// Retrieve uread messages count from the Zendesk SDK
   static Future<int> messageCount() async {
     try {
       return await _channel.invokeMethod(
@@ -154,6 +155,7 @@ class ZendeskMessaging {
     }
   }
 
+///  Check if the Zendesk SDK for Android and iOS is already initialized
   static Future<bool> isInitialized() async {
     try {
       return await _channel.invokeMethod(

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -12,7 +12,7 @@ enum ZendeskMessagingMessageType {
   loginFailure,
   logoutSuccess,
   logoutFailure,
-  messageCount,
+  incomingMessage,
 }
 
 /// Used by ZendeskMessaging to attach custom async observers
@@ -39,19 +39,17 @@ class ZendeskMessaging {
     "login_failure": ZendeskMessagingMessageType.loginFailure,
     "logout_success": ZendeskMessagingMessageType.logoutSuccess,
     "logout_failure": ZendeskMessagingMessageType.logoutFailure,
-    "message_count": ZendeskMessagingMessageType.messageCount,
+    "incoming_message": ZendeskMessagingMessageType.incomingMessage,
   };
 
   /// Global handler, all channel method calls will trigger this observer
   static Function(ZendeskMessagingMessageType type, Map? arguments)? _handler;
 
   /// Allow end-user to use local observer when calling some methods
-  static final Map<ZendeskMessagingMessageType, ZendeskMessagingObserver>
-      _observers = {};
+  static final Map<ZendeskMessagingMessageType, ZendeskMessagingObserver> _observers = {};
 
   /// Attach a global observer for incoming messages
-  static void setMessageHandler(
-      Function(ZendeskMessagingMessageType type, Map? arguments)? handler) {
+  static void setMessageHandler(Function(ZendeskMessagingMessageType type, Map? arguments)? handler) {
     _handler = handler;
   }
 
@@ -59,17 +57,16 @@ class ZendeskMessaging {
   ///
   /// @param  androidChannelKey  The Android SDK key generated from Zendesk dashboard
   /// @param  iosChannelKey      The iOS SDK key generated from the Zendesk dashboard
-  static Future<void> initialize(
-      {required String androidChannelKey,
-      required String iosChannelKey}) async {
+  static Future<void> initialize({required String androidChannelKey, required String iosChannelKey}) async {
     if (androidChannelKey.isEmpty || iosChannelKey.isEmpty) {
       debugPrint('ZendeskMessaging - initialize - keys can not be empty');
       return;
     }
 
     try {
-      _channel.setMethodCallHandler(
-          _onMethodCall); // start observing channel messages
+      _channel.setMethodCallHandler(_onMethodCall); // start observing channel messages
+      _setObserver(ZendeskMessagingMessageType.incomingMessage, (args) {
+      });
       await _channel.invokeMethod('initialize', {
         'channelKey': Platform.isAndroid ? androidChannelKey : iosChannelKey,
       });
@@ -95,22 +92,16 @@ class ZendeskMessaging {
   /// @param  onSuccess Optional - If you need to be notified about the login success
   /// @param  onFailure Optional - If you need to be notified about the login failure
   static Future<void> loginUserCallbacks(
-      {required String jwt,
-      Function(String? id, String? externalId)? onSuccess,
-      Function()? onFailure}) async {
+      {required String jwt, Function(String? id, String? externalId)? onSuccess, Function()? onFailure}) async {
     if (jwt.isEmpty) {
       debugPrint('ZendeskMessaging - loginUser - jwt can not be empty');
       return;
     }
 
     try {
-      _setObserver(
-          ZendeskMessagingMessageType.loginSuccess,
-          onSuccess != null
-              ? (Map? args) => onSuccess(args?["id"], args?["externalId"])
-              : null);
-      _setObserver(ZendeskMessagingMessageType.loginFailure,
-          onFailure != null ? (Map? args) => onFailure() : null);
+      _setObserver(ZendeskMessagingMessageType.loginSuccess,
+          onSuccess != null ? (Map? args) => onSuccess(args?["id"], args?["externalId"]) : null);
+      _setObserver(ZendeskMessagingMessageType.loginFailure, onFailure != null ? (Map? args) => onFailure() : null);
 
       await _channel.invokeMethod('loginUser', {'jwt': jwt});
     } catch (e) {
@@ -125,10 +116,8 @@ class ZendeskMessaging {
     var completer = Completer<ZendeskLoginResponse>();
     await loginUserCallbacks(
       jwt: jwt,
-      onSuccess: (id, externalId) =>
-          completer.complete(ZendeskLoginResponse(id, externalId)),
-      onFailure: () =>
-          completer.completeError(Exception("Zendesk::loginUser failed")),
+      onSuccess: (id, externalId) => completer.complete(ZendeskLoginResponse(id, externalId)),
+      onFailure: () => completer.completeError(Exception("Zendesk::loginUser failed")),
     );
     return completer.future;
   }
@@ -137,13 +126,10 @@ class ZendeskMessaging {
   ///
   /// @param  onSuccess Optional - If you need to be notified about the logout success
   /// @param  onFailure Optional - If you need to be notified about the logout failure
-  static Future<void> logoutUserCallbacks(
-      {Function()? onSuccess, Function()? onFailure}) async {
+  static Future<void> logoutUserCallbacks({Function()? onSuccess, Function()? onFailure}) async {
     try {
-      _setObserver(ZendeskMessagingMessageType.logoutSuccess,
-          onSuccess != null ? (Map? args) => onSuccess() : null);
-      _setObserver(ZendeskMessagingMessageType.logoutFailure,
-          onFailure != null ? (Map? args) => onFailure() : null);
+      _setObserver(ZendeskMessagingMessageType.logoutSuccess, onSuccess != null ? (Map? args) => onSuccess() : null);
+      _setObserver(ZendeskMessagingMessageType.logoutFailure, onFailure != null ? (Map? args) => onFailure() : null);
 
       await _channel.invokeMethod('logoutUser');
     } catch (e) {
@@ -156,8 +142,7 @@ class ZendeskMessaging {
     var completer = Completer<void>();
     await logoutUserCallbacks(
       onSuccess: () => completer.complete(),
-      onFailure: () =>
-          completer.completeError(Exception("Zendesk::logoutUser failed")),
+      onFailure: () => completer.completeError(Exception("Zendesk::logoutUser failed")),
     );
     return completer.future;
   }
@@ -172,9 +157,10 @@ class ZendeskMessaging {
       return 0;
     }
   }
-  static Future<bool> isInitialized()async  {
+
+  static Future<bool> isInitialized() async {
     try {
-      return  await _channel.invokeMethod(
+      return await _channel.invokeMethod(
         'isInitialized',
       );
     } catch (e) {
@@ -189,8 +175,7 @@ class ZendeskMessaging {
       return;
     }
 
-    final ZendeskMessagingMessageType type =
-        channelMethodToMessageType[call.method]!;
+    final ZendeskMessagingMessageType type = channelMethodToMessageType[call.method]!;
     var globalHandler = _handler;
     if (globalHandler != null) {
       globalHandler(type, call.arguments);
@@ -207,9 +192,7 @@ class ZendeskMessaging {
   }
 
   /// Add an observer for a specific type
-  static _setObserver(
-      ZendeskMessagingMessageType type, Function(Map? args)? func,
-      {bool removeOnCall = true}) {
+  static _setObserver(ZendeskMessagingMessageType type, Function(Map? args)? func, {bool removeOnCall = true}) {
     if (func == null) {
       _observers.remove(type);
     } else {

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -66,8 +66,10 @@ class ZendeskMessaging {
       await _channel.invokeMethod('initialize', {
         'channelKey': Platform.isAndroid ? androidChannelKey : iosChannelKey,
       });
+      return;
     } catch (e) {
       debugPrint('ZendeskMessaging - initialize - Error: $e}');
+      return;
     }
   }
 

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -168,8 +168,18 @@ class ZendeskMessaging {
         'countMessages',
       );
     } catch (e) {
-      debugPrint('ZendeskMessaging - count - Error: $e}');
+      debugPrint('ZendeskMessaging - isInitialized - Error: $e}');
       return 0;
+    }
+  }
+  static Future<bool> isInitialized()async  {
+    try {
+      return  await _channel.invokeMethod(
+        'isInitialized',
+      );
+    } catch (e) {
+      debugPrint('ZendeskMessaging - count - Error: $e}');
+      return false;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zendesk_messaging
 description: Zendesk-Messaging for Flutter developer
-version: 2.7.0
+version: 2.7.1
 homepage: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging
 
 environment:


### PR DESCRIPTION
## What is the content type?
-  Improvement

## Why is this change necessary?
 - It's quite useful to be able to retrieve the unread message count available on the native SDK
 
## How does this address the issue?
- We added the necessary mapping from the native sdk methods to the flutter method channel, allowing the user to retrieve the unread message count.

## How to use?

After authenticating the user, one can retrieve the unread message count using:

```dart
final int count = await await ZendeskMessaging.messageCount();
```
