### PR TITLE
fix: change the parameter type of handler function

### DIFF
--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -30,7 +30,7 @@ public class ZendeskMessaging: NSObject {
             } else {
                 self.zendeskPlugin?.isInitialized = true
                 print("\(self.TAG) - initialize success")
-                self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [])
+                self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [:])
             }
         }
     }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -41,13 +41,13 @@ class ZendeskMessaging {
   };
 
   /// Global handler, all channel method calls will trigger this observer
-  static Function(ZendeskMessagingMessageType type, dynamic arguments)? _handler;
+  static Function(ZendeskMessagingMessageType type, Map? arguments)? _handler;
 
   /// Allow end-user to use local observer when calling some methods
   static final Map<ZendeskMessagingMessageType, ZendeskMessagingObserver> _observers = {};
 
   /// Attach a global observer for incoming messages
-  static void setMessageHandler(Function(ZendeskMessagingMessageType type, dynamic arguments)? handler) {
+  static void setMessageHandler(Function(ZendeskMessagingMessageType type, Map? arguments)? handler) {
     _handler = handler;
   }
 


### PR DESCRIPTION
When Zendesk is initialized successfully on iOS platform, the code 
`self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [])`
is invoked, in which` [] `is interpreted as a List and passed to Flutter, conflicted with the type of field  _hander in dart class ZendeskMessaging
`static Function(ZendeskMessagingMessageType type, Map? arguments)? _handler;`

So when the plugin runned on iOS, type error happend.