### PR TITLE
Add conversation tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ final int count = await ZendeskMessaging.getUnreadMessageCount()();
 
 // if there's no user logged in, the message count will always be zero.
 ```
+### Set tags to a support ticket (optional)
+
+Allows custom conversation tags to be set, adding contextual data about the conversation.
+
+```dart
+// Add tags to a conversation
+ await ZendeskMessaging.setConversationTags(['tag1', 'tag2', 'tag3']);
+
+// Note: Conversation tags are not immediately associated with a conversation when this method is called. 
+// It will only be applied to a conversation when end users either start a new conversation or send a new message in an existing conversation.
+```
+### Clear conversation tags (optional)
+
+Allows custom conversation tags to be set, adding contextual data about the conversation.
+
+```dart
+// Allows you to clear conversation tags from native SDK storage when the client side context changes.
+// This removes all stored conversation tags from the natice SDK storage.
+ await ZendeskMessaging.clearConversationTags();
+
+// Note: This method does not affect conversation tags already applied to the conversation.
+```
 
 ### Global observer (optional)
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ ZendeskMessaging.setMessageHandler((type, args){
 });
 ```
 
-## Weak
-- **Tag**：`Currently does not support.` There is no way to help users with additional information like Chat.
+## Known shortcomings
 - **Attachment file**：`Currently does not support.` The official said it will be launched in the future.
 - **Chat room closed**：An agent can not reply to a customer at any time.
 if the customer is not active in the foreground, the room will be closed automatically. It is inconvenient to track chat history.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,5 +48,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "zendesk.messaging:messaging-android:2.11.0"
+    implementation "zendesk.messaging:messaging-android:2.13.0"
 }

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -47,6 +47,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         Zendesk.instance.messaging.showMessaging(plugin.activity!!, Intent.FLAG_ACTIVITY_NEW_TASK)
         println("$tag - show")
     }
+
     fun getUnreadMessageCount(): Int {
         return try {
             Zendesk.instance.messaging.getUnreadMessageCount()
@@ -55,6 +56,14 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         }
     }
 
+    fun setConversationTags(tags: List<String>){
+        Zendesk.instance.messaging.setConversationTags(tags)
+    }
+
+    fun clearConversationTags(){
+        Zendesk.instance.messaging.clearConversationTags()
+    }
+    
     fun loginUser(jwt: String) {
         Zendesk.instance.loginUser(
             jwt,

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -75,6 +75,32 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 result.success(zendeskMessaging.getUnreadMessageCount())
             }
+            "setConversationTags" -> {
+                if (!isInitialized) {
+                    println("$tag - Messaging needs to be initialized first")
+                    return
+                }
+
+                try {
+                    val tags = call.argument<List<String>>("tags")
+                    if (tags == null) {
+                        throw Exception("tags is empty or null")
+                    }
+
+                    zendeskMessaging.setConversationTags(tags)
+                } catch (err: Throwable) {
+                    println("$tag - Messaging::setConversationTags invalid arguments. {'tags': '<your_tags>'} expected !")
+                    println(err.message)
+                    return
+                }
+            }
+            "clearConversationTags" -> {
+                if (!isInitialized) {
+                    println("$tag - Messaging needs to be initialized first")
+                    return
+                }
+                zendeskMessaging.clearConversationTags()
+            }
             else -> {
                 result.notImplemented()
             }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,6 +68,14 @@ class _MyAppState extends State<MyApp> {
                   ),
                 ],
                 ElevatedButton(
+                  onPressed: () => _setTags(),
+                  child: const Text("Add tags"),
+                ),
+                ElevatedButton(
+                  onPressed: () => _clearTags(),
+                  child: const Text("Clear tags"),
+                ),
+                ElevatedButton(
                   onPressed: () => _login(),
                   child: const Text("Login"),
                 ),
@@ -111,5 +119,12 @@ class _MyAppState extends State<MyApp> {
       unreadMessageCount = messageCount;
       setState(() {});
     }
+  }
+  void _setTags() async {
+    final tags = ['tag1', 'tag2', 'tag3'];
+    await ZendeskMessaging.setConversationTags(tags);
+  }
+  void _clearTags() async {
+    await ZendeskMessaging.clearConversationTags();
   }
 }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -61,6 +61,20 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
             case "isInitialized":
                 result(handleInitializedStatus())
                 break
+            
+            case "setConversationTags":
+                if (!isInitialized) {
+                    print("\(TAG) - Messaging needs to be initialized first.\n")
+                }
+                let tags: [String] = arguments?["tags"] as! [String]
+                zendeskMessaging.setConversationTags(tags:tags)
+                break
+            case "clearConversationTags":
+                if (!isInitialized) {
+                    print("\(TAG) - Messaging needs to be initialized first.\n")
+                }
+                zendeskMessaging.clearConversationTags()
+                break
             default:
                 break
         }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -41,6 +41,14 @@ public class ZendeskMessaging: NSObject {
         rootViewController.present(messagingViewController, animated: true, completion: nil)
         print("\(self.TAG) - show")
     }
+
+    func setConversationTags(tags: [String]) {
+        Zendesk.instance?.messaging?.setConversationTags(tags)
+    }
+
+    func clearConversationTags() {
+        Zendesk.instance?.messaging?.clearConversationTags()
+    }
     
     func loginUser(jwt: String) {
         Zendesk.instance?.loginUser(with: jwt) { result in

--- a/ios/zendesk_messaging.podspec
+++ b/ios/zendesk_messaging.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'zendesk_messaging'
-  s.version          = '2.11.0'
+  s.version          = '2.13.1'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ZendeskSDKMessaging', '2.11.0'
+  s.dependency 'ZendeskSDKMessaging', '2.13.1'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -82,6 +82,33 @@ class ZendeskMessaging {
     }
   }
 
+  /// Add a list of tags to a support ticket
+  /// 
+  /// Conversation tags are not immediately associated with a conversation when this method is called. 
+  /// It will only be applied to a conversation when end users either start a new 
+  /// conversation or send a new message in an existing conversation.
+  /// 
+  /// For example, to apply "promo_code" and "discount" tags to a conversation about an order, then you would call:
+  /// `ZendeskMessaging.setConversationTags(["promo_code","discount"])`
+  static Future<void> setConversationTags(List<String> tags) async {
+    try {
+      await _channel.invokeMethod('setConversationTags',
+          {'tags': tags});
+    } catch (e) {
+      debugPrint('ZendeskMessaging - setConversationTags - Error: $e}');
+    }
+  }
+
+/// Remove all the tags on the current support ticket
+/// 
+  static Future<void> clearConversationTags() async {
+    try {
+      await _channel.invokeMethod('clearConversationTags');
+    } catch (e) {
+      debugPrint('ZendeskMessaging - clearConversationTags - Error: $e}');
+    }
+  }
+
   /// Authenticate the current session with a JWT
   ///
   /// @param  jwt       Required by the SDK - You must generate it from your backend


### PR DESCRIPTION
## What is the content type?

- [ ] Bugfix
- [X] Feature
- [ ] Improvement

## Why is this change necessary?

- Currently, the package does not support the addition of tags to a conversation.
Recently the Zendesk team improved the native SDKs to allow tags to be set by the client side, thus allowing this improvement on the Flutter side.

## How does this address the issue?

- Adds the ability for the client to set conversation tags.
