### PR TITLE
Add invalidate method to ZendeskMessaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@
 ```
 > just use initialize() one time
 
+### Invalidate (optional)
+``` dart
+@override
+  void dispose() {
+    ZendeskMessaging.invalidate();
+    super.dispose();
+  }
+///  Invalidates the current instance of ZendeskMessaging.
+```
+After calling this method you will have to call ZendeskMessaging.initialize again if you would like to use ZendeskMessaging.
+
+This can be useful if you need to initiate a chat with another set of `androidChannelKey` and `iosChannelKey`
+
 ### Show
 ```dart
 ZendeskMessaging.show();
@@ -60,7 +73,7 @@ final ZendeskLoginResponse result = await ZendeskMessaging.loginUser(jwt: "YOUR_
 await ZendeskMessaging.logoutUser();
 
 // Method 2 if you need callbacks
-await ZendeskMessaging.loginUserCallbacks(jwt: "YOUR_JWT", onSuccess: (id, externalId) => ..., onFailure: () => ...;
+await ZendeskMessaging.loginUserCallbacks(jwt: "YOUR_JWT", onSuccess: (id, externalId) => ..., onFailure: () => ...);
 await ZendeskMessaging.logoutUserCallbacks(onSuccess: () => ..., onFailure: () => ...);
 ```
 ### Retrieve the unread message count (optional)

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -43,6 +43,11 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         )
     }
 
+    fun invalidate() {
+        Zendesk.invalidate()
+        plugin.isInitialized = false;
+    }
+
     fun show() {
         Zendesk.instance.messaging.showMessaging(plugin.activity!!, Intent.FLAG_ACTIVITY_NEW_TASK)
         println("$tag - show")
@@ -63,7 +68,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
     fun clearConversationTags(){
         Zendesk.instance.messaging.clearConversationTags()
     }
-    
+
     fun loginUser(jwt: String) {
         Zendesk.instance.loginUser(
             jwt,

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -46,6 +46,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
     fun invalidate() {
         Zendesk.invalidate()
         plugin.isInitialized = false;
+        println("$tag - invalidated")
     }
 
     fun show() {

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -101,6 +101,13 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 zendeskMessaging.clearConversationTags()
             }
+            "invalidate" -> {
+                if (!isInitialized) {
+                    println("$tag - Messaging is already on an invalid state")
+                    return
+                }
+                zendeskMessaging.invalidate()
+            }
             else -> {
                 result.notImplemented()
             }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
   - Flutter (1.0.0)
-  - Zendesk (1.11.0):
-    - ZendeskSDKConversationKit (~> 1.8.0)
-    - ZendeskSDKCoreUtilities (~> 1.2.0)
-  - zendesk_messaging (2.11.0):
+  - Zendesk (1.14.0):
+    - ZendeskSDKConversationKit (~> 1.11.0)
+    - ZendeskSDKCoreUtilities (~> 1.5.0)
+  - zendesk_messaging (2.13.1):
     - Flutter
-    - ZendeskSDKMessaging (= 2.11.0)
-  - ZendeskSDKConversationKit (1.8.0):
-    - ZendeskSDKCoreUtilities (~> 1.2.0)
-    - ZendeskSDKFayeClient (~> 1.3.0)
-    - ZendeskSDKHTTPClient (~> 0.11.0)
-    - ZendeskSDKStorage (~> 0.6.0)
-  - ZendeskSDKCoreUtilities (1.2.0)
-  - ZendeskSDKFayeClient (1.3.0):
-    - ZendeskSDKLogger (~> 0.6.0)
-    - ZendeskSDKSocketClient (~> 1.3.0)
-  - ZendeskSDKHTTPClient (0.11.0):
-    - ZendeskSDKLogger (~> 0.6.0)
-  - ZendeskSDKLogger (0.6.0)
-  - ZendeskSDKMessaging (2.11.0):
-    - Zendesk (~> 1.11.0)
-    - ZendeskSDKConversationKit (~> 1.8.0)
-    - ZendeskSDKCoreUtilities (~> 1.2.0)
-    - ZendeskSDKUIComponents (~> 2.6.0)
-  - ZendeskSDKSocketClient (1.3.0):
-    - ZendeskSDKLogger (~> 0.6.0)
-  - ZendeskSDKStorage (0.6.0):
-    - ZendeskSDKLogger (~> 0.6.0)
-  - ZendeskSDKUIComponents (2.6.0)
+    - ZendeskSDKMessaging (= 2.13.1)
+  - ZendeskSDKConversationKit (1.11.0):
+    - ZendeskSDKCoreUtilities (~> 1.5.0)
+    - ZendeskSDKFayeClient (~> 1.5.0)
+    - ZendeskSDKHTTPClient (~> 0.13.0)
+    - ZendeskSDKStorage (~> 0.8.0)
+  - ZendeskSDKCoreUtilities (1.5.0)
+  - ZendeskSDKFayeClient (1.5.0):
+    - ZendeskSDKLogger (~> 0.8.0)
+    - ZendeskSDKSocketClient (~> 1.5.0)
+  - ZendeskSDKHTTPClient (0.13.0):
+    - ZendeskSDKLogger (~> 0.8.0)
+  - ZendeskSDKLogger (0.8.0)
+  - ZendeskSDKMessaging (2.13.1):
+    - Zendesk (~> 1.14.0)
+    - ZendeskSDKConversationKit (~> 1.11.0)
+    - ZendeskSDKCoreUtilities (~> 1.5.0)
+    - ZendeskSDKUIComponents (~> 2.8.0)
+  - ZendeskSDKSocketClient (1.5.0):
+    - ZendeskSDKLogger (~> 0.8.0)
+  - ZendeskSDKStorage (0.8.0):
+    - ZendeskSDKLogger (~> 0.8.0)
+  - ZendeskSDKUIComponents (2.8.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -54,18 +54,18 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  Zendesk: 4e1b5e6fd3a28034868e4bc9bb490020e2efadd0
-  zendesk_messaging: b6bec17d7fe6ce4c9096d2a8860728be15615adc
-  ZendeskSDKConversationKit: 2360456d7b7d181e9bfca97c86cf9d0726274984
-  ZendeskSDKCoreUtilities: 7b6e55b31f6ffec8ff1b2a84797ebb447c623b2f
-  ZendeskSDKFayeClient: 169812e13a1f3d175b38449b37a5e23b19fd3908
-  ZendeskSDKHTTPClient: 81ccf190c1221ff7e4980ddf719711c4ce5baffb
-  ZendeskSDKLogger: aee4388c6c6fc341ec57bbb87479768130b796da
-  ZendeskSDKMessaging: 6199b37f8b62ba266be741b979a72db8251c629d
-  ZendeskSDKSocketClient: 53b9481906f38b5d35833535260cd872f5f28a27
-  ZendeskSDKStorage: cc4fcbfd50544d8fe26d5cfdc63f5c6455152e5e
-  ZendeskSDKUIComponents: e2bc335781ae57c13fddb1512dc3c0c56403c0aa
+  Zendesk: f76348b53a84c1100e7d56aa5dd80d00e94a48f0
+  zendesk_messaging: 3a9dc2817d1073b5877209eaad2d4ccd2bb6f711
+  ZendeskSDKConversationKit: 54f2ff2ffa80d89eb1d77134c4b5df4157fb0051
+  ZendeskSDKCoreUtilities: cbf0a4afea966e01ba206a4760dc46f15840edc3
+  ZendeskSDKFayeClient: a06c403c1c38adb9ae5a341a4d54632c78275a3e
+  ZendeskSDKHTTPClient: 79dfe6b5e75beccb435003051a081c71e7361770
+  ZendeskSDKLogger: e59c678c74a88838a0844423996cb15dd88825d5
+  ZendeskSDKMessaging: f960c52823dbecfe7ca05a9cadd1d3ffc7de6107
+  ZendeskSDKSocketClient: 33c0eb83b065409723559c798738bbc504b0a967
+  ZendeskSDKStorage: 00d6f78a39a42b71c3730b1c39cc0a5c12690685
+  ZendeskSDKUIComponents: 59fab9ac52f3ac5ef3136188da8dc38b06d100f7
 
 PODFILE CHECKSUM: 7368163408c647b7eb699d0d788ba6718e18fb8d
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,6 +33,12 @@ class _MyAppState extends State<MyApp> {
   }
 
   @override
+  void dispose() {
+    ZendeskMessaging.invalidate();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final message = channelMessages.join("\n");
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
@@ -67,6 +67,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -79,18 +87,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -116,10 +124,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -156,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -168,14 +176,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   zendesk_messaging:
     dependency: "direct main"
     description:
@@ -184,5 +184,5 @@ packages:
     source: path
     version: "2.7.6"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.16.0"

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -75,6 +75,13 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 zendeskMessaging.clearConversationTags()
                 break
+            case "invalidate":
+                if (!isInitialized) {
+                    println("$tag - Messaging is already on an invalid state")
+                    return
+                }
+                zendeskMessaging.invalidate()
+                break
             default:
                 break
         }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -77,7 +77,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 break
             case "invalidate":
                 if (!isInitialized) {
-                    println("$tag - Messaging is already on an invalid state")
+                    print("\(TAG) - Messaging is already on an invalid state\n")
                     return
                 }
                 zendeskMessaging.invalidate()

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -38,6 +38,7 @@ public class ZendeskMessaging: NSObject {
      func invalidate() {
         Zendesk.invalidate()
        self.zendeskPlugin?.isInitialized = false
+       print("\(self.TAG) - invalidate")
     }
 
     func show(rootViewController: UIViewController?) {

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -35,6 +35,11 @@ public class ZendeskMessaging: NSObject {
         }
     }
 
+     func invalidate() {
+        Zendesk.invalidate()
+       self.zendeskPlugin?.isInitialized = false
+    }
+
     func show(rootViewController: UIViewController?) {
         guard let messagingViewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
         guard let rootViewController = rootViewController else { return }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -73,8 +73,8 @@ class ZendeskMessaging {
     }
   }
 
-  /// Invalidates the current instance of Zendesk.
-/// After calling this method you will have to call Zendesk.initialize again if you would like to use Zendesk.
+  /// Invalidates the current instance of ZendeskMessaging.
+/// After calling this method you will have to call ZendeskMessaging.initialize again if you would like to use ZendeskMessaging.
   static Future<void> invalidate() async {
     try {
       await _channel.invokeMethod('invalidate');

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -73,6 +73,16 @@ class ZendeskMessaging {
     }
   }
 
+  /// Invalidates the current instance of Zendesk.
+/// After calling this method you will have to call Zendesk.initialize again if you would like to use Zendesk.
+  static Future<void> invalidate() async {
+    try {
+      await _channel.invokeMethod('invalidate');
+    } catch (e) {
+      debugPrint('ZendeskMessaging - invalidate - Error: $e}');
+    }
+  }
+
   /// Start the Zendesk Messaging UI
   static Future<void> show() async {
     try {


### PR DESCRIPTION
## What is the content type?

- [ ] Bugfix
- [X] Feature
- [ ] Improvement

## Why is this change necessary?

- This PR aims to solve #27 

## How does this address the issue?

- Implements the `invalidate()` method available on the Messaging SDK, exposing it to flutter users

## How to use it?

Whenever needed, call:

```Dart
ZendeskMessaging.invalidate()
```
This will invalidate the current instance of `ZendeskMessaging`, allowing you to call:

```Dart
ZendeskMessaging.initialize(
      androidChannelKey: androidChannelKey,
      iosChannelKey: iosChannelKey,
    );
```
With a new set of  `androidChannelKey` and `iosChannelKey`, this is useful if you have subbrands in your Zendesk usecases and so they each need their own channel keys.

