### PR TITLE
Add login status checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ await ZendeskMessaging.logoutUser();
 await ZendeskMessaging.loginUserCallbacks(jwt: "YOUR_JWT", onSuccess: (id, externalId) => ..., onFailure: () => ...);
 await ZendeskMessaging.logoutUserCallbacks(onSuccess: () => ..., onFailure: () => ...);
 ```
+### Check authentication state (optional)
+
+This method can be used to check wheter the user is alreday logged in!
+
+```dart
+await ZendeskMessaging.loginUser(jwt: "YOUR_JWT");
+final bool isLoggedIn = await ZendeskMessaging.isLoggedIn();
+// After the user is logged in [isLoggedIn] is true
+await ZendeskMessaging.logoutUser();
+final bool userStillLoggedIn = await ZendeskMessaging.isLoggedIn();
+// After you call the logout method [ZendeskMessaging.isLoggedIn()] will return [false]
+
+```
 ### Retrieve the unread message count (optional)
 
 There's must be a logged user to allow the recovery of the unread message count!

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -74,6 +74,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         Zendesk.instance.loginUser(
             jwt,
             { value: ZendeskUser? ->
+                plugin.isLoggedIn = true;
                 value?.let {
                     channel.invokeMethod(loginSuccess, mapOf("id" to it.id, "externalId" to it.externalId))
                 } ?: run {
@@ -91,6 +92,7 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
         GlobalScope.launch (Dispatchers.Main)  {
             try {
                 Zendesk.instance.logoutUser(successCallback = {
+                    plugin.isLoggedIn = false;
                     channel.invokeMethod(logoutSuccess, null)
                 }, failureCallback = {
                     channel.invokeMethod(logoutFailure, null)

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -19,6 +19,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     var activity: Activity? = null
     var isInitialized: Boolean = false
+    var isLoggedIn: Boolean = false
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
         val sendData: Any? = call.arguments
@@ -42,6 +43,11 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
             "isInitialized" -> {
                 result.success(isInitialized)
+                return
+            }
+            "isLoggedIn" -> {
+                result.success(isLoggedIn)
+                return
             }
             "loginUser" -> {
                 if (!isInitialized) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -89,6 +89,10 @@ class _MyAppState extends State<MyApp> {
                   onPressed: () => _logout(),
                   child: const Text("Logout"),
                 ),
+                ElevatedButton(
+                  onPressed: () => _checkUserLoggedIn(),
+                  child: const Text("Check LoggedIn"),
+                ),
               ],
             ),
           ),
@@ -118,8 +122,7 @@ class _MyAppState extends State<MyApp> {
       isLogin = false;
     });
   }
-
-  void _getUnreadMessageCount() async {
+    void _getUnreadMessageCount() async {
     final messageCount = await ZendeskMessaging.getUnreadMessageCount();
     if (mounted) {
       unreadMessageCount = messageCount;
@@ -132,5 +135,11 @@ class _MyAppState extends State<MyApp> {
   }
   void _clearTags() async {
     await ZendeskMessaging.clearConversationTags();
+  }
+  void _checkUserLoggedIn()async {
+   final isLoggedIn = await ZendeskMessaging.isLoggedIn();
+   setState(() {
+     channelMessages.add('User is ${isLoggedIn?'':'not'} logged in');
+   });
   }
 }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -5,6 +5,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     let TAG = "[SwiftZendeskMessagingPlugin]"
     private var channel: FlutterMethodChannel
     var isInitialized = false
+    var isLoggedIn = false
     
     init(channel: FlutterMethodChannel) {
         self.channel = channel
@@ -61,6 +62,9 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
             case "isInitialized":
                 result(handleInitializedStatus())
                 break
+            case "isLoggedIn":
+                result(handleLoggedInStatus())
+                break
             
             case "setConversationTags":
                 if (!isInitialized) {
@@ -96,5 +100,8 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     }
     private func handleInitializedStatus() ->Bool{
         return isInitialized
+    }
+    private func handleLoggedInStatus() ->Bool{
+        return isLoggedIn
     }
 }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -60,6 +60,7 @@ public class ZendeskMessaging: NSObject {
         Zendesk.instance?.loginUser(with: jwt) { result in
             switch result {
             case .success(let user):
+            self.zendeskPlugin?.isLoggedIn = true
                 self.channel?.invokeMethod(ZendeskMessaging.loginSuccess, arguments: ["id": user.id, "externalId": user.externalId])
                 break;
             case .failure(let error):
@@ -74,6 +75,7 @@ public class ZendeskMessaging: NSObject {
         Zendesk.instance?.logoutUser { result in
             switch result {
             case .success:
+                self.zendeskPlugin?.isLoggedIn = false
                 self.channel?.invokeMethod(ZendeskMessaging.logoutSuccess, arguments: [])
                 break;
             case .failure(let error):

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -203,6 +203,17 @@ class ZendeskMessaging {
       return false;
     }
   }
+  ///  Check if the user is already logged in
+  static Future<bool> isLoggedIn() async {
+    try {
+      return await _channel.invokeMethod(
+        'isLoggedIn',
+      );
+    } catch (e) {
+      debugPrint('ZendeskMessaging - isLoggedIn - Error: $e}');
+      return false;
+    }
+  }
 
   /// Handle incoming message from platforms (iOS and Android)
   static Future<dynamic> _onMethodCall(final MethodCall call) async {


### PR DESCRIPTION
## What is the content type?

- [ ] Bugfix
- [X] Feature
- [ ] Improvement

## Why is this change necessary?

- This PR aims to solve #28 

## How does this address the issue?

- Implements the `isLoggedIn()` method,  which allows checking the login status of your users.

## How to use it?

Whenever needed, call:

```Dart
ZendeskMessaging.isLoggedIn()
```
This method will return :

```Dart
Future<bool>
```
This will resolve to `false` if the user is not logged in and to `true` if you already successfully called the login method previously.

