### PR TITLE
ADD conversation field implementation

### DIFF
--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -103,6 +103,12 @@ class ZendeskMessaging(private val plugin: ZendeskMessagingPlugin, private val c
             }
         }
     }
+
+    fun setConversationFields(fields: Map<String, String>){
+        Zendesk.instance.messaging.setConversationFields(fields)
+    }
+
+    fun clearConversationFields(){
+        Zendesk.instance.messaging.clearConversationFields()
+    }
 }
-
-

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -107,6 +107,32 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
                 zendeskMessaging.clearConversationTags()
             }
+            "setConversationFields" -> {
+                if (!isInitialized) {
+                    println("$tag - Messaging needs to be initialized first")
+                    return
+                }
+
+                try {
+                    val fields = call.argument<Map<String, String>>("fields")
+                    if (fields == null) {
+                        throw Exception("fields is empty or null")
+                    }
+
+                    zendeskMessaging.setConversationFields(fields)
+                } catch (err: Throwable) {
+                    println("$tag - Messaging::setConversationFields invalid arguments. {'fields': Map<String, String>}. expected !")
+                    println(err.message)
+                    return
+                }
+            }
+            "clearConversationFields" -> {
+                if (!isInitialized) {
+                    println("$tag - Messaging needs to be initialized first")
+                    return
+                }
+                zendeskMessaging.clearConversationFields()
+            }
             "invalidate" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging is already on an invalid state")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,6 +93,18 @@ class _MyAppState extends State<MyApp> {
                   onPressed: () => _checkUserLoggedIn(),
                   child: const Text("Check LoggedIn"),
                 ),
+                ElevatedButton(
+                  onPressed: () => _setFields(),
+                  child: const Text("Add Fields"),
+                ),
+                ElevatedButton(
+                  onPressed: () => _clearFields(),
+                  child: const Text("Clear Fields"),
+                ),
+                ElevatedButton(
+                  onPressed: () => _show(),
+                  child: const Text("Show"),
+                ),
               ],
             ),
           ),
@@ -141,5 +153,19 @@ class _MyAppState extends State<MyApp> {
    setState(() {
      channelMessages.add('User is ${isLoggedIn?'':'not'} logged in');
    });
+  }
+  void _setFields() async {
+    Map<String, String> fieldsMap = {};
+
+    fieldsMap["field1"] = "Value 1";
+    fieldsMap["field2"] = "Value 2";
+
+    await ZendeskMessaging.setConversationFields(fieldsMap);
+  }
+  void _clearFields() async {
+    await ZendeskMessaging.clearConversationFields();
+  }
+  void _show() {
+    ZendeskMessaging.show();
   }
 }

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -79,6 +79,19 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 zendeskMessaging.clearConversationTags()
                 break
+            case "setConversationFields":
+                if (!isInitialized) {
+                    print("\(TAG) - Messaging needs to be initialized first.\n")
+                }
+                let fields: [String: String] = arguments?["fields"] as! [String: String]
+                zendeskMessaging.setConversationFields(fields:fields)
+                break
+            case "clearConversationFields":
+                if (!isInitialized) {
+                    print("\(TAG) - Messaging needs to be initialized first.\n")
+                }
+                zendeskMessaging.clearConversationFields()
+                break
             case "invalidate":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging is already on an invalid state\n")

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -89,4 +89,12 @@ public class ZendeskMessaging: NSObject {
         let count = Zendesk.instance?.messaging?.getUnreadMessageCount()
         return count ?? 0
     }
+
+    func setConversationFields(fields: [String: String]) {
+        Zendesk.instance?.messaging?.setConversationFields(fields)
+    }
+
+    func clearConversationFields() {
+        Zendesk.instance?.messaging?.clearConversationFields()
+    }
 }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -245,4 +245,40 @@ class ZendeskMessaging {
       _observers[type] = ZendeskMessagingObserver(removeOnCall, func);
     }
   }
+
+  /// Set values for conversation fields in the SDK to add contextual data about the conversation.
+  ///
+  /// This method allows setting custom field values which are used to add additional context to a conversation in Zendesk.
+  /// Conversation fields must be created as custom ticket fields in the Zendesk Admin Center and configured to be settable by end users.
+  ///
+  /// Note: Conversation fields are not immediately associated with a conversation when this method is called.
+  /// The fields will only be applied to a conversation when end users start a new conversation or send a new message in an existing conversation.
+  ///
+  /// System ticket fields, such as the Priority field, are not supported.
+  ///
+  /// The values set by this method are persisted in the SDK and will apply to all conversations going forward.
+  /// To remove fields, use the `ClearConversationFields` API.
+  ///
+  /// Example:
+  /// To set custom fields "user_type" and "purchase_amount" for a conversation, use the following call:
+  /// ```
+  /// setConversationFields({"user_type": "new_user", "purchase_amount": "39.99"});
+  /// ```
+  static Future<void> setConversationFields(Map<String, String> fields) async {
+    try {
+      await _channel.invokeMethod('setConversationFields', {'fields': fields});
+    } catch (e) {
+      debugPrint('ZendeskMessaging - setConversationFields - Error: $e}');
+    }
+  }
+
+  /// Remove all the fields on the current support ticket
+  ///
+  static Future<void> clearConversationFields() async {
+    try {
+      await _channel.invokeMethod('clearConversationFields');
+    } catch (e) {
+      debugPrint('ZendeskMessaging - clearConversationFields - Error: $e}');
+    }
+  }
 }


### PR DESCRIPTION
## What is the content type?

 - [ ] Bugfix
 - [x] Feature
 - [ ] Improvement
 
## Why is this change necessary?
Currently, the package does not support the addition of fields to a conversation.
Recently the Zendesk team improved the native SDKs to allow fields to be set by the client side, thus allowing this improvement on the Flutter side.

## How does this address the issue?
Adds the ability for the client to set conversation fields.