### PR TITLE
WRAP channel calls with dispatch

### DIFF
--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -19,11 +19,16 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        DispatchQueue.main.async {
+            self.processMethodCall(call, result: result)
+        }
+    }
+
+    private func processMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let method = call.method
         let arguments = call.arguments as? Dictionary<String, Any>
         let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
-
-        // chat sdk method channels
+        
         switch(method){
             case "initialize":
                 if (isInitialized) {
@@ -100,10 +105,8 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 zendeskMessaging.invalidate()
                 break
             default:
-                break
+                result(FlutterMethodNotImplemented)
         }
-
-        result(nil)
     }
 
     private func handleMessageCount() ->Int{

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -23,28 +23,60 @@ public class ZendeskMessaging: NSObject {
     func initialize(channelKey: String) {
         print("\(self.TAG) - Channel Key - \(channelKey)\n")
         Zendesk.initialize(withChannelKey: channelKey, messagingFactory: DefaultMessagingFactory()) { result in
-            if case let .failure(error) = result {
-                self.zendeskPlugin?.isInitialized = false
-                print("\(self.TAG) - initialize failure - \(error.localizedDescription)\n")
-                self.channel?.invokeMethod(ZendeskMessaging.initializeFailure, arguments: ["error": error.localizedDescription])
-            } else {
-                self.zendeskPlugin?.isInitialized = true
-                print("\(self.TAG) - initialize success")
-                self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [:])
+            DispatchQueue.main.async {
+                if case let .failure(error) = result {
+                    self.zendeskPlugin?.isInitialized = false
+                    print("\(self.TAG) - initialize failure - \(error.localizedDescription)\n")
+                    self.channel?.invokeMethod(ZendeskMessaging.initializeFailure, arguments: ["error": error.localizedDescription])
+                } else {
+                    self.zendeskPlugin?.isInitialized = true
+                    print("\(self.TAG) - initialize success")
+                    self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [:])
+                }
             }
         }
     }
 
-     func invalidate() {
+    func invalidate() {
         Zendesk.invalidate()
        self.zendeskPlugin?.isInitialized = false
        print("\(self.TAG) - invalidate")
     }
 
-    func show(rootViewController: UIViewController?) {
+    /*func show(rootViewController: UIViewController?) {
         guard let messagingViewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
         guard let rootViewController = rootViewController else { return }
         rootViewController.present(messagingViewController, animated: true, completion: nil)
+        print("\(self.TAG) - show")
+    }*/
+    
+    func show(rootViewController: UIViewController?) {
+        guard let messagingViewController = Zendesk.instance?.messaging?.messagingViewController() as? UIViewController else {
+            print("\(self.TAG) - Unable to create Zendesk messaging view controller")
+            return
+        }
+        guard let rootViewController = rootViewController else {
+            print("\(self.TAG) - Root view controller is nil")
+            return
+        }
+
+        // Check if rootViewController is already presenting another view controller
+        if let presentedVC = rootViewController.presentedViewController {
+            // Check if the presentedVC is the same instance as messagingViewController
+            if presentedVC === messagingViewController {
+                // If the same instance, do nothing or update it as necessary
+                print("\(self.TAG) - Zendesk messaging view controller is already presented")
+            } else {
+                // Dismiss current and present new, or just present new
+                presentedVC.dismiss(animated: true) {
+                    rootViewController.present(messagingViewController, animated: true, completion: nil)
+                }
+            }
+        } else {
+            // No view controller is being presented, present the new one
+            rootViewController.present(messagingViewController, animated: true, completion: nil)
+        }
+
         print("\(self.TAG) - show")
     }
 
@@ -58,33 +90,38 @@ public class ZendeskMessaging: NSObject {
     
     func loginUser(jwt: String) {
         Zendesk.instance?.loginUser(with: jwt) { result in
-            switch result {
-            case .success(let user):
-            self.zendeskPlugin?.isLoggedIn = true
-                self.channel?.invokeMethod(ZendeskMessaging.loginSuccess, arguments: ["id": user.id, "externalId": user.externalId])
-                break;
-            case .failure(let error):
-                print("\(self.TAG) - login failure - \(error.localizedDescription)\n")
-                self.channel?.invokeMethod(ZendeskMessaging.loginFailure, arguments: ["error": nil])
-                break;
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let user):
+                    self.zendeskPlugin?.isLoggedIn = true
+                    self.channel?.invokeMethod(ZendeskMessaging.loginSuccess, arguments: ["id": user.id, "externalId": user.externalId])
+                    break
+                case .failure(let error):
+                    print("\(self.TAG) - login failure - \(error.localizedDescription)\n")
+                    self.channel?.invokeMethod(ZendeskMessaging.loginFailure, arguments: ["error": nil])
+                    break
+                }
             }
         }
     }
     
     func logoutUser() {
         Zendesk.instance?.logoutUser { result in
-            switch result {
-            case .success:
-                self.zendeskPlugin?.isLoggedIn = false
-                self.channel?.invokeMethod(ZendeskMessaging.logoutSuccess, arguments: [])
-                break;
-            case .failure(let error):
-                print("\(self.TAG) - logout failure - \(error.localizedDescription)\n")
-                self.channel?.invokeMethod(ZendeskMessaging.logoutFailure, arguments: ["error": nil])
-                break;
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.zendeskPlugin?.isLoggedIn = false
+                    self.channel?.invokeMethod(ZendeskMessaging.logoutSuccess, arguments: [])
+                    break
+                case .failure(let error):
+                    print("\(self.TAG) - logout failure - \(error.localizedDescription)\n")
+                    self.channel?.invokeMethod(ZendeskMessaging.logoutFailure, arguments: ["error": nil])
+                    break
+                }
             }
         }
     }
+    
     func getUnreadMessageCount() -> Int {
         let count = Zendesk.instance?.messaging?.getUnreadMessageCount()
         return count ?? 0

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -42,13 +42,6 @@ public class ZendeskMessaging: NSObject {
        self.zendeskPlugin?.isInitialized = false
        print("\(self.TAG) - invalidate")
     }
-
-    /*func show(rootViewController: UIViewController?) {
-        guard let messagingViewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
-        guard let rootViewController = rootViewController else { return }
-        rootViewController.present(messagingViewController, animated: true, completion: nil)
-        print("\(self.TAG) - show")
-    }*/
     
     func show(rootViewController: UIViewController?) {
         guard let messagingViewController = Zendesk.instance?.messaging?.messagingViewController() as? UIViewController else {


### PR DESCRIPTION
## What is the content type?

 - [ ] Bugfix
 - [x] Feature
 - [ ] Improvement
 
## Why is this change necessary?
Messages are being sent from a non-platform thread to Flutter; according to the documentation, we should ensure that all interactions with the Flutter MethodChannel occur on the main thread. 

## How does this address the issue?
To ensure thread safety and compliance with Flutter's platform channel requirements, this update modifies the handling of asynchronous callbacks from the Zendesk SDK.