### PR TITLE
Fix crash on logout due to TypeError in method channel arguments

### DIFF
--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -287,7 +287,12 @@ class ZendeskMessaging {
     // call all observers too
     final observer = _observers[type];
     if (observer != null) {
-      observer.func(call.arguments);
+      final args = call.arguments;
+      if (args is List && args.isEmpty) {
+        observer.func(null);
+      } else {
+        observer.func(call.arguments);
+      }
       if (observer.removeOnCall) {
         _setObserver(type, null);
       }


### PR DESCRIPTION
This PR fixes the issue where the app crashes when logging out the user using `ZendeskMessaging.logoutUser()` on iOS. The crash was caused by a type mismatch in the method channel arguments.

Arguments sometimes is `List`:
<img width="372" alt="image" src="https://github.com/user-attachments/assets/ffd3740b-0772-4da4-9401-2744a84a400f">


Closes #56 
