### PR TITLE
Fix method channel calls never complete

### DIFF
--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -36,26 +36,26 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                     return
                 }
                 let channelKey: String = (arguments?["channelKey"] ?? "") as! String
-                zendeskMessaging.initialize(channelKey: channelKey)
+                zendeskMessaging.initialize(channelKey: channelKey, flutterResult: result)
                 break;
             case "show":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
-                zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController)
+                zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
                 break
             case "loginUser":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 let jwt: String = arguments?["jwt"] as! String
-                zendeskMessaging.loginUser(jwt: jwt)
+                zendeskMessaging.loginUser(jwt: jwt, flutterResult: result)
                 break
             case "logoutUser":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
-                zendeskMessaging.logoutUser()
+                zendeskMessaging.logoutUser(flutterResult: result)
                 break
             case "getUnreadMessageCount":
                 if (!isInitialized) {
@@ -77,12 +77,14 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 let tags: [String] = arguments?["tags"] as! [String]
                 zendeskMessaging.setConversationTags(tags:tags)
+                result(nil)
                 break
             case "clearConversationTags":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.clearConversationTags()
+                result(nil)
                 break
             case "setConversationFields":
                 if (!isInitialized) {
@@ -90,12 +92,14 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 let fields: [String: String] = arguments?["fields"] as! [String: String]
                 zendeskMessaging.setConversationFields(fields:fields)
+                result(nil)
                 break
             case "clearConversationFields":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.clearConversationFields()
+                result(nil)
                 break
             case "invalidate":
                 if (!isInitialized) {
@@ -103,6 +107,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                     return
                 }
                 zendeskMessaging.invalidate()
+                result(nil)
                 break
             default:
                 result(FlutterMethodNotImplemented)

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -37,40 +37,31 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 let channelKey: String = (arguments?["channelKey"] ?? "") as! String
                 zendeskMessaging.initialize(channelKey: channelKey, flutterResult: result)
-                break;
             case "show":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
-                break
             case "loginUser":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 let jwt: String = arguments?["jwt"] as! String
                 zendeskMessaging.loginUser(jwt: jwt, flutterResult: result)
-                break
             case "logoutUser":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.logoutUser(flutterResult: result)
-                break
             case "getUnreadMessageCount":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 result(handleMessageCount())
-                break
-            
             case "isInitialized":
                 result(handleInitializedStatus())
-                break
             case "isLoggedIn":
                 result(handleLoggedInStatus())
-                break
-            
             case "setConversationTags":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
@@ -78,14 +69,12 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 let tags: [String] = arguments?["tags"] as! [String]
                 zendeskMessaging.setConversationTags(tags:tags)
                 result(nil)
-                break
             case "clearConversationTags":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.clearConversationTags()
                 result(nil)
-                break
             case "setConversationFields":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
@@ -93,14 +82,12 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 let fields: [String: String] = arguments?["fields"] as! [String: String]
                 zendeskMessaging.setConversationFields(fields:fields)
                 result(nil)
-                break
             case "clearConversationFields":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging needs to be initialized first.\n")
                 }
                 zendeskMessaging.clearConversationFields()
                 result(nil)
-                break
             case "invalidate":
                 if (!isInitialized) {
                     print("\(TAG) - Messaging is already on an invalid state\n")
@@ -108,7 +95,6 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 }
                 zendeskMessaging.invalidate()
                 result(nil)
-                break
             default:
                 result(FlutterMethodNotImplemented)
         }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -90,11 +90,9 @@ public class ZendeskMessaging: NSObject {
                 case .success(let user):
                     self.zendeskPlugin?.isLoggedIn = true
                     self.channel?.invokeMethod(ZendeskMessaging.loginSuccess, arguments: ["id": user.id, "externalId": user.externalId])
-                    break
                 case .failure(let error):
                     print("\(self.TAG) - login failure - \(error.localizedDescription)\n")
                     self.channel?.invokeMethod(ZendeskMessaging.loginFailure, arguments: ["error": nil])
-                    break
                 }
                 flutterResult(nil)
             }
@@ -108,11 +106,9 @@ public class ZendeskMessaging: NSObject {
                 case .success:
                     self.zendeskPlugin?.isLoggedIn = false
                     self.channel?.invokeMethod(ZendeskMessaging.logoutSuccess, arguments: [:])
-                    break
                 case .failure(let error):
                     print("\(self.TAG) - logout failure - \(error.localizedDescription)\n")
                     self.channel?.invokeMethod(ZendeskMessaging.logoutFailure, arguments: ["error": nil])
-                    break
                 }
                 flutterResult(nil)
             }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -20,7 +20,7 @@ public class ZendeskMessaging: NSObject {
         self.channel = channel
     }
     
-    func initialize(channelKey: String) {
+    func initialize(channelKey: String, flutterResult: @escaping FlutterResult) {
         print("\(self.TAG) - Channel Key - \(channelKey)\n")
         Zendesk.initialize(withChannelKey: channelKey, messagingFactory: DefaultMessagingFactory()) { result in
             DispatchQueue.main.async {
@@ -33,17 +33,18 @@ public class ZendeskMessaging: NSObject {
                     print("\(self.TAG) - initialize success")
                     self.channel?.invokeMethod(ZendeskMessaging.initializeSuccess, arguments: [:])
                 }
+                flutterResult(nil)
             }
         }
     }
 
     func invalidate() {
         Zendesk.invalidate()
-       self.zendeskPlugin?.isInitialized = false
-       print("\(self.TAG) - invalidate")
+        self.zendeskPlugin?.isInitialized = false
+        print("\(self.TAG) - invalidate")
     }
     
-    func show(rootViewController: UIViewController?) {
+    func show(rootViewController: UIViewController?, flutterResult: @escaping FlutterResult) {
         guard let messagingViewController = Zendesk.instance?.messaging?.messagingViewController() as? UIViewController else {
             print("\(self.TAG) - Unable to create Zendesk messaging view controller")
             return
@@ -56,7 +57,7 @@ public class ZendeskMessaging: NSObject {
         // Check if rootViewController is already presenting another view controller
         let navController = UINavigationController(rootViewController: messagingViewController)
 
-    // Present the navigation controller
+        // Present the navigation controller
         DispatchQueue.main.async {
             if let presentedVC = rootViewController.presentedViewController {
                 if presentedVC !== navController {
@@ -69,6 +70,7 @@ public class ZendeskMessaging: NSObject {
             } else {
                 rootViewController.present(navController, animated: true, completion: nil)
             }
+            flutterResult(nil)
         }
         print("\(self.TAG) - show")
     }
@@ -81,7 +83,7 @@ public class ZendeskMessaging: NSObject {
         Zendesk.instance?.messaging?.clearConversationTags()
     }
     
-    func loginUser(jwt: String) {
+    func loginUser(jwt: String, flutterResult: @escaping FlutterResult) {
         Zendesk.instance?.loginUser(with: jwt) { result in
             DispatchQueue.main.async {
                 switch result {
@@ -94,11 +96,12 @@ public class ZendeskMessaging: NSObject {
                     self.channel?.invokeMethod(ZendeskMessaging.loginFailure, arguments: ["error": nil])
                     break
                 }
+                flutterResult(nil)
             }
         }
     }
     
-    func logoutUser() {
+    func logoutUser(flutterResult: @escaping FlutterResult) {
         Zendesk.instance?.logoutUser { result in
             DispatchQueue.main.async {
                 switch result {
@@ -111,6 +114,7 @@ public class ZendeskMessaging: NSObject {
                     self.channel?.invokeMethod(ZendeskMessaging.logoutFailure, arguments: ["error": nil])
                     break
                 }
+                flutterResult(nil)
             }
         }
     }

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -267,7 +267,7 @@ class ZendeskMessaging {
   /// Handle incoming message from platforms (iOS and Android)
   static Future<dynamic> _onMethodCall(final MethodCall call) async {
     final method = call.method;
-    final arguments = call.arguments as Map<String, dynamic>?;
+    final arguments = Map<String, dynamic>.from(call.arguments);
 
     if (!channelMethodToMessageType.containsKey(method)) {
       return;


### PR DESCRIPTION
Resolves #59 

- [x] Fix parsing arguments from the method channel exception
- [x] Add the missing method channel result calls to fix method channel calls never complete issue
- [x] Remove unnecessary `break` in the Swift switch case 