### PR TITLE
Android Method Channel Calls Never Complete

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="com.chyiiiiiiiiiiiiii.zendesk_messaging">
+<manifest>
 </manifest>

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -1,5 +1,6 @@
+package com.chyiiiiiiiiiiiiii.zendesk_messaging
+
 import android.content.Intent
-import com.chyiiiiiiiiiiiiii.zendesk_messaging.ZendeskMessagingPlugin
 import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -9,7 +10,6 @@ import zendesk.android.ZendeskUser
 import zendesk.android.events.ZendeskEvent
 import zendesk.android.events.ZendeskEventListener
 import zendesk.messaging.android.DefaultMessagingFactory
-
 
 class ZendeskMessaging(
     private val plugin: ZendeskMessagingPlugin,

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -19,13 +19,13 @@ class ZendeskMessaging(
         const val TAG = "[ZendeskMessaging]"
 
         // Method channel callback keys
-        const val initializeSuccess: String = "initialize_success"
-        const val initializeFailure: String = "initialize_failure"
-        const val loginSuccess: String = "login_success"
-        const val loginFailure: String = "login_failure"
-        const val logoutSuccess: String = "logout_success"
-        const val logoutFailure: String = "logout_failure"
-        const val unreadMessages: String = "unread_messages"
+        const val INITIALIZE_SUCCESS: String = "initialize_success"
+        const val INITIALIZE_FAILURE: String = "initialize_failure"
+        const val LOGIN_SUCCESS: String = "login_success"
+        const val LOGIN_FAILURE: String = "login_failure"
+        const val LOGOUT_SUCCESS: String = "logout_success"
+        const val LOGOUT_FAILURE: String = "logout_failure"
+        const val UNREAD_MESSAGES: String = "unread_messages"
     }
 
     // To create and use the event listener:
@@ -34,7 +34,7 @@ class ZendeskMessaging(
             is ZendeskEvent.UnreadMessageCountChanged -> {
 
                 channel.invokeMethod(
-                    unreadMessages,
+                    UNREAD_MESSAGES,
                     mapOf("messages_count" to zendeskEvent.currentUnreadCount)
                 )
 
@@ -54,12 +54,12 @@ class ZendeskMessaging(
             successCallback = { value ->
                 plugin.isInitialized = true
                 println("$TAG - initialize success - $value")
-                channel.invokeMethod(initializeSuccess, null)
+                channel.invokeMethod(INITIALIZE_SUCCESS, null)
             },
             failureCallback = { error ->
                 plugin.isInitialized = false
                 println("$TAG - initialize failure - $error")
-                channel.invokeMethod(initializeFailure, mapOf("error" to error.message))
+                channel.invokeMethod(INITIALIZE_FAILURE, mapOf("error" to error.message))
             },
             messagingFactory = DefaultMessagingFactory()
         )
@@ -99,17 +99,17 @@ class ZendeskMessaging(
                 plugin.isLoggedIn = true
                 value?.let {
                     channel.invokeMethod(
-                        loginSuccess,
+                        LOGIN_SUCCESS,
                         mapOf("id" to it.id, "externalId" to it.externalId)
                     )
                 } ?: run {
-                    channel.invokeMethod(loginSuccess, mapOf("id" to null, "externalId" to null))
+                    channel.invokeMethod(LOGIN_SUCCESS, mapOf("id" to null, "externalId" to null))
                 }
             },
             { error: Throwable? ->
                 println("$TAG - Login failure : ${error?.message}")
                 println(error)
-                channel.invokeMethod(loginFailure, mapOf("error" to error?.message))
+                channel.invokeMethod(LOGIN_FAILURE, mapOf("error" to error?.message))
             })
     }
 
@@ -118,14 +118,14 @@ class ZendeskMessaging(
             try {
                 Zendesk.instance.logoutUser(successCallback = {
                     plugin.isLoggedIn = false
-                    channel.invokeMethod(logoutSuccess, null)
+                    channel.invokeMethod(LOGOUT_SUCCESS, null)
                 }, failureCallback = {
-                    channel.invokeMethod(logoutFailure, null)
+                    channel.invokeMethod(LOGOUT_FAILURE, null)
                 })
                 Zendesk.instance.removeEventListener(zendeskEventListener)
             } catch (error: Throwable) {
                 println("$TAG - Logout failure : ${error.message}")
-                channel.invokeMethod(logoutFailure, mapOf("error" to error.message))
+                channel.invokeMethod(LOGOUT_FAILURE, mapOf("error" to error.message))
             }
         }
     }

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -1,6 +1,5 @@
 package com.chyiiiiiiiiiiiiii.zendesk_messaging
 
-import ZendeskMessaging
 import android.app.Activity
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -28,7 +27,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         when (call.method) {
             "initialize" -> {
                 if (isInitialized) {
-                    println("$tag - Messaging is already initialized!")
+                    println("$tag - Zendesk SDK is already initialized!")
                     reportAlreadyInitializedFlutterError(result)
                     return
                 }
@@ -39,7 +38,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "show" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -57,7 +56,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "loginUser" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -70,7 +69,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     zendeskMessaging.loginUser(jwt)
                     result.success(null)
                 } catch (err: Throwable) {
-                    println("$tag - Messaging::login invalid arguments. {'jwt': '<your_jwt>'} expected !")
+                    println("$tag - ZendeskMessaging::login invalid arguments. {'jwt': '<your_jwt>'} expected !")
                     println(err.message)
                     result.error("login_error", err.message, null)
                 }
@@ -78,7 +77,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "logoutUser" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -88,7 +87,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "getUnreadMessageCount" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -97,7 +96,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "listenUnreadMessages" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -106,7 +105,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     zendeskMessaging.listenMessageCountChanged()
                     result.success(null)
                 } catch (err: Throwable) {
-                    println("$tag - Messaging::listen unread Messages error")
+                    println("$tag - ZendeskMessaging::listen unread Messages error")
                     println(err.message)
                     result.error("listen_unread_messages_error", err.message, null)
                 }
@@ -114,7 +113,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "setConversationTags" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -126,7 +125,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     zendeskMessaging.setConversationTags(tags)
                     result.success(null)
                 } catch (err: Throwable) {
-                    println("$tag - Messaging::setConversationTags invalid arguments. {'tags': '<your_tags>'} expected !")
+                    println("$tag - ZendeskMessaging::setConversationTags invalid arguments. {'tags': '<your_tags>'} expected !")
                     println(err.message)
                     result.error("set_conversation_tags_error", err.message, null)
                 }
@@ -134,7 +133,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "clearConversationTags" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -144,7 +143,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "setConversationFields" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -156,7 +155,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     zendeskMessaging.setConversationFields(fields)
                     result.success(null)
                 } catch (err: Throwable) {
-                    println("$tag - Messaging::setConversationFields invalid arguments. {'fields': Map<String, String>}. expected !")
+                    println("$tag - ZendeskMessaging::setConversationFields invalid arguments. {'fields': Map<String, String>}. expected !")
                     println(err.message)
                     result.error("set_conversation_fields_error", err.message, null)
                 }
@@ -164,7 +163,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "clearConversationFields" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging needs to be initialized first")
+                    println("$tag - Zendesk SDK needs to be initialized first")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -174,7 +173,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             "invalidate" -> {
                 if (!isInitialized) {
-                    println("$tag - Messaging is already on an invalid state")
+                    println("$tag - Zendesk SDK is already on an invalid state")
                     reportNotInitializedFlutterError(result)
                     return
                 }
@@ -197,7 +196,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun reportAlreadyInitializedFlutterError(result: MethodChannel.Result) {
         result.error(
             "already_initialized",
-            "ZendeskMessaging is already initialized",
+            "Zendesk SDK is already initialized",
             null
         )
     }
@@ -205,7 +204,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private fun reportNotInitializedFlutterError(result: MethodChannel.Result) {
         result.error(
             "not_initialized",
-            "ZendeskMessaging needs to be initialized first",
+            "Zendesk SDK needs to be initialized first",
             null
         )
     }

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -2,13 +2,13 @@ package com.chyiiiiiiiiiiiiii.zendesk_messaging
 
 import ZendeskMessaging
 import android.app.Activity
-import androidx.annotation.NonNull
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+
 /** ZendeskMessagingPlugin */
 class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     /// The MethodChannel that will the communication between Flutter and native Android
@@ -21,7 +21,7 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     var isInitialized: Boolean = false
     var isLoggedIn: Boolean = false
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannel.Result) {
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         val sendData: Any? = call.arguments
         val zendeskMessaging = ZendeskMessaging(this, channel)
 
@@ -29,132 +29,159 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "initialize" -> {
                 if (isInitialized) {
                     println("$tag - Messaging is already initialized!")
+                    reportAlreadyInitializedFlutterError(result)
                     return
                 }
                 val channelKey = call.argument<String>("channelKey")!!
                 zendeskMessaging.initialize(channelKey)
+                result.success(null)
             }
+
             "show" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
                 zendeskMessaging.show()
+                result.success(null)
             }
+
             "isInitialized" -> {
                 result.success(isInitialized)
-                return
             }
+
             "isLoggedIn" -> {
                 result.success(isLoggedIn)
-                return
             }
+
             "loginUser" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
 
                 try {
                     val jwt = call.argument<String>("jwt")
-                    if (jwt == null || jwt.isEmpty()) {
+                    if (jwt.isNullOrEmpty()) {
                         throw Exception("JWT is empty or null")
                     }
                     zendeskMessaging.loginUser(jwt)
+                    result.success(null)
                 } catch (err: Throwable) {
                     println("$tag - Messaging::login invalid arguments. {'jwt': '<your_jwt>'} expected !")
                     println(err.message)
-                    return
+                    result.error("login_error", err.message, null)
                 }
             }
+
             "logoutUser" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
                 zendeskMessaging.logoutUser()
+                result.success(null)
             }
+
             "getUnreadMessageCount" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
                 result.success(zendeskMessaging.getUnreadMessageCount())
-                return
             }
+
             "listenUnreadMessages" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
 
                 try {
                     zendeskMessaging.listenMessageCountChanged()
+                    result.success(null)
                 } catch (err: Throwable) {
                     println("$tag - Messaging::listen unread Messages error")
                     println(err.message)
-                    return
+                    result.error("listen_unread_messages_error", err.message, null)
                 }
             }
+
             "setConversationTags" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
 
                 try {
                     val tags = call.argument<List<String>>("tags")
-                    if (tags == null) {
-                        throw Exception("tags is empty or null")
-                    }
+                        ?: throw Exception("tags is empty or null")
 
                     zendeskMessaging.setConversationTags(tags)
+                    result.success(null)
                 } catch (err: Throwable) {
                     println("$tag - Messaging::setConversationTags invalid arguments. {'tags': '<your_tags>'} expected !")
                     println(err.message)
-                    return
+                    result.error("set_conversation_tags_error", err.message, null)
                 }
             }
+
             "clearConversationTags" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
                 zendeskMessaging.clearConversationTags()
+                result.success(null)
             }
+
             "setConversationFields" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
 
                 try {
                     val fields = call.argument<Map<String, String>>("fields")
-                    if (fields == null) {
-                        throw Exception("fields is empty or null")
-                    }
+                        ?: throw Exception("fields is empty or null")
 
                     zendeskMessaging.setConversationFields(fields)
+                    result.success(null)
                 } catch (err: Throwable) {
                     println("$tag - Messaging::setConversationFields invalid arguments. {'fields': Map<String, String>}. expected !")
                     println(err.message)
-                    return
+                    result.error("set_conversation_fields_error", err.message, null)
                 }
             }
+
             "clearConversationFields" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
                 zendeskMessaging.clearConversationFields()
+                result.success(null)
             }
+
             "invalidate" -> {
                 if (!isInitialized) {
                     println("$tag - Messaging is already on an invalid state")
+                    reportNotInitializedFlutterError(result)
                     return
                 }
                 zendeskMessaging.invalidate()
+                result.success(null)
             }
+
             else -> {
                 result.notImplemented()
             }
@@ -167,12 +194,28 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
     }
 
-    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    private fun reportAlreadyInitializedFlutterError(result: MethodChannel.Result) {
+        result.error(
+            "already_initialized",
+            "ZendeskMessaging is already initialized",
+            null
+        )
+    }
+
+    private fun reportNotInitializedFlutterError(result: MethodChannel.Result) {
+        result.error(
+            "not_initialized",
+            "ZendeskMessaging needs to be initialized first",
+            null
+        )
+    }
+
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "zendesk_messaging")
         channel.setMethodCallHandler(this)
     }
 
-    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
     }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,6 +6,7 @@ allprojects {
 }
 
 rootProject.buildDir = "../build"
+
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version '8.7.2' apply false
     id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }
 


### PR DESCRIPTION
- [x] Upgrade Gradle and AGP version
- [x] Remove redundant android property in root build.gradle
- [x] Resolve all lint.
- [x] Add `result.success` or `result.error` for each method channel call.
- [x] Remove redundant `GlobalScope.launch()` in `logout` method. Because Zendesk SDK own their scope inside the SDK.
- [x] Update log message.