### PR TITLE
Fix duplicate method channel reply and argument parsing error

### DIFF
--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -15,15 +15,21 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     /// This local reference serves to register the plugin with the Flutter Engine and unregister it
     /// when the Flutter Engine is detached from the Activity
     private val tag = "[ZendeskMessagingPlugin]"
+
     private lateinit var channel: MethodChannel
+    private lateinit var zendeskMessaging: ZendeskMessaging
+
     var activity: Activity? = null
     var isInitialized: Boolean = false
     var isLoggedIn: Boolean = false
 
-    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-        val sendData: Any? = call.arguments
-        val zendeskMessaging = ZendeskMessaging(this, channel)
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "zendesk_messaging")
+        channel.setMethodCallHandler(this)
+        zendeskMessaging = ZendeskMessaging(this, channel)
+    }
 
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
             "initialize" -> {
                 if (isInitialized) {
@@ -185,12 +191,6 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.notImplemented()
             }
         }
-
-        if (sendData != null) {
-            result.success(sendData)
-        } else {
-            result.success(0)
-        }
     }
 
     private fun reportAlreadyInitializedFlutterError(result: MethodChannel.Result) {
@@ -207,11 +207,6 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "Zendesk SDK needs to be initialized first",
             null
         )
-    }
-
-    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "zendesk_messaging")
-        channel.setMethodCallHandler(this)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -281,7 +281,9 @@ class ZendeskMessaging {
   /// Handle incoming message from platforms (iOS and Android)
   static Future<dynamic> _onMethodCall(final MethodCall call) async {
     final method = call.method;
-    final arguments = Map<String, dynamic>.from(call.arguments);
+    final arguments = call.arguments != null
+        ? Map<String, dynamic>.from(call.arguments)
+        : <String, dynamic>{};
 
     if (!channelMethodToMessageType.containsKey(method)) {
       return;

--- a/lib/zendesk_messaging.dart
+++ b/lib/zendesk_messaging.dart
@@ -84,7 +84,7 @@ class ZendeskMessaging {
         completer.completeError(PlatformException(
             code: 'initialize_error', message: args?['error'] as String?));
       });
-      return completer.future.timeout(const Duration(seconds: 3));
+      return completer.future;
     } catch (e) {
       debugPrint('ZendeskMessaging - initialize - Error: $e}');
     }


### PR DESCRIPTION
- [x] Remove redundant `sendData` code for method channel result.
- [x] Fix argument parsing error on dart side.