### PR TITLE
Adjust method channel mechanism on iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -111,10 +111,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> _login() async {
     // You can attach local observer when calling some methods to be notified when ready
     try {
-      final response = await ZendeskMessaging.loginUser(
-        jwt:
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImFwcF82NzI4NDRmYmVhYjdjODAyMGI0NDNhYzkifQ.eyJleHRlcm5hbF9pZCI6IjY0NjQ4M2Y3NzlmOWVmOTM3ZmZlMTY3YyIsIm5hbWUiOiJ3YWdneXQiLCJzY29wZSI6InVzZXIifQ.E4neOzbw0aU7IPMJQxD3UFnOXOmQgMRRUlogCEaVbmU',
-      );
+      final response = await ZendeskMessaging.loginUser(jwt: 'my_jwt');
       setState(() {
         channelMessages.add(
             "Login observer - SUCCESS: ${response.id}, ${response.externalId}");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -111,13 +111,20 @@ class _MyAppState extends State<MyApp> {
   Future<void> _login() async {
     // You can attach local observer when calling some methods to be notified when ready
     try {
-      final response = await ZendeskMessaging.loginUser(jwt: 'my_jwt');
-      channelMessages.add(
-          "Login observer - SUCCESS: ${response.id}, ${response.externalId}");
-      isLogin = true;
+      final response = await ZendeskMessaging.loginUser(
+        jwt:
+            'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImFwcF82NzI4NDRmYmVhYjdjODAyMGI0NDNhYzkifQ.eyJleHRlcm5hbF9pZCI6IjY0NjQ4M2Y3NzlmOWVmOTM3ZmZlMTY3YyIsIm5hbWUiOiJ3YWdneXQiLCJzY29wZSI6InVzZXIifQ.E4neOzbw0aU7IPMJQxD3UFnOXOmQgMRRUlogCEaVbmU',
+      );
+      setState(() {
+        channelMessages.add(
+            "Login observer - SUCCESS: ${response.id}, ${response.externalId}");
+        isLogin = true;
+      });
     } catch (e) {
-      channelMessages.add("Login observer - FAILURE!");
-      isLogin = false;
+      setState(() {
+        channelMessages.add("Login observer - FAILURE!");
+        isLogin = false;
+      });
     }
   }
 

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -4,11 +4,14 @@ import UIKit
 public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     let TAG = "[SwiftZendeskMessagingPlugin]"
     private var channel: FlutterMethodChannel
+    private var zendeskMessaging: ZendeskMessaging?
     var isInitialized = false
     var isLoggedIn = false
     
     init(channel: FlutterMethodChannel) {
         self.channel = channel
+        super.init();
+        self.zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
     }
     
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -27,19 +30,19 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     private func processMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let method = call.method
         let arguments = call.arguments as? Dictionary<String, Any>
-        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
+        
         
         switch(method){
         case "initialize":
             let channelKey: String = (arguments?["channelKey"] ?? "") as! String
-            zendeskMessaging.initialize(channelKey: channelKey, flutterResult: result)
+            zendeskMessaging?.initialize(channelKey: channelKey, flutterResult: result)
         case "show":
             if (!isInitialized) {
                 print("\(TAG) - Messaging needs to be initialized first.\n")
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
+            zendeskMessaging?.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
         case "loginUser":
             if (!isInitialized) {
                 print("\(TAG) - Messaging needs to be initialized first.\n")
@@ -47,14 +50,14 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 return
             }
             let jwt: String = arguments?["jwt"] as! String
-            zendeskMessaging.loginUser(jwt: jwt, flutterResult: result)
+            zendeskMessaging?.loginUser(jwt: jwt, flutterResult: result)
         case "logoutUser":
             if (!isInitialized) {
                 print("\(TAG) - Messaging needs to be initialized first.\n")
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging.logoutUser(flutterResult: result)
+            zendeskMessaging?.logoutUser(flutterResult: result)
         case "getUnreadMessageCount":
             if (!isInitialized) {
                 print("\(TAG) - Messaging needs to be initialized first.\n")
@@ -73,7 +76,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 return
             }
             let tags: [String] = arguments?["tags"] as! [String]
-            zendeskMessaging.setConversationTags(tags:tags)
+            zendeskMessaging?.setConversationTags(tags:tags)
             result(nil)
         case "clearConversationTags":
             if (!isInitialized) {
@@ -81,7 +84,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging.clearConversationTags()
+            zendeskMessaging?.clearConversationTags()
             result(nil)
         case "setConversationFields":
             if (!isInitialized) {
@@ -90,7 +93,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 return
             }
             let fields: [String: String] = arguments?["fields"] as! [String: String]
-            zendeskMessaging.setConversationFields(fields:fields)
+            zendeskMessaging?.setConversationFields(fields:fields)
             result(nil)
         case "clearConversationFields":
             if (!isInitialized) {
@@ -98,7 +101,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging.clearConversationFields()
+            zendeskMessaging?.clearConversationFields()
             result(nil)
         case "invalidate":
             if (!isInitialized) {
@@ -106,7 +109,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging.invalidate()
+            zendeskMessaging?.invalidate()
             result(nil)
         default:
             result(FlutterMethodNotImplemented)
@@ -114,8 +117,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     }
     
     private func handleMessageCount() -> Int {
-        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
-        return zendeskMessaging.getUnreadMessageCount()
+        return zendeskMessaging?.getUnreadMessageCount() ?? 0
     }
     
     private func handleInitializedStatus() -> Bool {

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -27,7 +27,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     private func processMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let method = call.method
         let arguments = call.arguments as? Dictionary<String, Any>
-        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self)
+        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
         
         switch(method){
         case "initialize":
@@ -114,7 +114,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
     }
     
     private func handleMessageCount() -> Int {
-        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self)
+        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
         return zendeskMessaging.getUnreadMessageCount()
     }
     

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -49,7 +49,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            let jwt: String = arguments?["jwt"] as! String
+            let jwt: String = arguments?["jwt"] as? String ?? ""
             zendeskMessaging?.loginUser(jwt: jwt, flutterResult: result)
         case "logoutUser":
             if (!isInitialized) {

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -23,92 +23,114 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
             self.processMethodCall(call, result: result)
         }
     }
-
+    
     private func processMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let method = call.method
         let arguments = call.arguments as? Dictionary<String, Any>
-        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
+        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self)
         
         switch(method){
-            case "initialize":
-                if (isInitialized) {
-                    print("\(TAG) - Messaging is already initialize!\n")
-                    return
-                }
-                let channelKey: String = (arguments?["channelKey"] ?? "") as! String
-                zendeskMessaging.initialize(channelKey: channelKey, flutterResult: result)
-            case "show":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
-            case "loginUser":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                let jwt: String = arguments?["jwt"] as! String
-                zendeskMessaging.loginUser(jwt: jwt, flutterResult: result)
-            case "logoutUser":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                zendeskMessaging.logoutUser(flutterResult: result)
-            case "getUnreadMessageCount":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                result(handleMessageCount())
-            case "isInitialized":
-                result(handleInitializedStatus())
-            case "isLoggedIn":
-                result(handleLoggedInStatus())
-            case "setConversationTags":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                let tags: [String] = arguments?["tags"] as! [String]
-                zendeskMessaging.setConversationTags(tags:tags)
-                result(nil)
-            case "clearConversationTags":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                zendeskMessaging.clearConversationTags()
-                result(nil)
-            case "setConversationFields":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                let fields: [String: String] = arguments?["fields"] as! [String: String]
-                zendeskMessaging.setConversationFields(fields:fields)
-                result(nil)
-            case "clearConversationFields":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging needs to be initialized first.\n")
-                }
-                zendeskMessaging.clearConversationFields()
-                result(nil)
-            case "invalidate":
-                if (!isInitialized) {
-                    print("\(TAG) - Messaging is already on an invalid state\n")
-                    return
-                }
-                zendeskMessaging.invalidate()
-                result(nil)
-            default:
-                result(FlutterMethodNotImplemented)
+        case "initialize":
+            let channelKey: String = (arguments?["channelKey"] ?? "") as! String
+            zendeskMessaging.initialize(channelKey: channelKey, flutterResult: result)
+        case "show":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            zendeskMessaging.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
+        case "loginUser":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            let jwt: String = arguments?["jwt"] as! String
+            zendeskMessaging.loginUser(jwt: jwt, flutterResult: result)
+        case "logoutUser":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            zendeskMessaging.logoutUser(flutterResult: result)
+        case "getUnreadMessageCount":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            result(handleMessageCount())
+        case "isInitialized":
+            result(handleInitializedStatus())
+        case "isLoggedIn":
+            result(handleLoggedInStatus())
+        case "setConversationTags":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            let tags: [String] = arguments?["tags"] as! [String]
+            zendeskMessaging.setConversationTags(tags:tags)
+            result(nil)
+        case "clearConversationTags":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            zendeskMessaging.clearConversationTags()
+            result(nil)
+        case "setConversationFields":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            let fields: [String: String] = arguments?["fields"] as! [String: String]
+            zendeskMessaging.setConversationFields(fields:fields)
+            result(nil)
+        case "clearConversationFields":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            zendeskMessaging.clearConversationFields()
+            result(nil)
+        case "invalidate":
+            if (!isInitialized) {
+                print("\(TAG) - Messaging is already on an invalid state\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            zendeskMessaging.invalidate()
+            result(nil)
+        default:
+            result(FlutterMethodNotImplemented)
         }
     }
-
-    private func handleMessageCount() ->Int{
-         let zendeskMessaging = ZendeskMessaging(flutterPlugin: self, channel: channel)
-
+    
+    private func handleMessageCount() -> Int {
+        let zendeskMessaging = ZendeskMessaging(flutterPlugin: self)
         return zendeskMessaging.getUnreadMessageCount()
     }
-    private func handleInitializedStatus() ->Bool{
+    
+    private func handleInitializedStatus() -> Bool {
         return isInitialized
     }
-    private func handleLoggedInStatus() ->Bool{
+    
+    private func handleLoggedInStatus() -> Bool {
         return isLoggedIn
+    }
+    
+    private func reportNotInitializedFlutterError(result: FlutterResult) {
+        result(FlutterError(
+            code: "not_initialized",
+            message: "Zendesk SDK needs to be initialized first",
+            details: nil)
+        )
     }
 }

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -5,10 +5,12 @@ import ZendeskSDK
 public class ZendeskMessaging: NSObject {
     let TAG = "[ZendeskMessaging]"
     
-    private var zendeskPlugin: SwiftZendeskMessagingPlugin? = nil
+    private var zendeskPlugin: SwiftZendeskMessagingPlugin
+    private let channel: FlutterMethodChannel
 
-    init(flutterPlugin: SwiftZendeskMessagingPlugin) {
+    init(flutterPlugin: SwiftZendeskMessagingPlugin, channel: FlutterMethodChannel) {
         self.zendeskPlugin = flutterPlugin
+        self.channel = channel
     }
     
     func initialize(channelKey: String, flutterResult: @escaping FlutterResult) {
@@ -16,7 +18,7 @@ public class ZendeskMessaging: NSObject {
         Zendesk.initialize(withChannelKey: channelKey, messagingFactory: DefaultMessagingFactory()) { result in
             DispatchQueue.main.async {
                 if case let .failure(error) = result {
-                    self.zendeskPlugin?.isInitialized = false
+                    self.zendeskPlugin.isInitialized = false
                     print("\(self.TAG) - initialize failure - \(error.localizedDescription)\n")
                     flutterResult(FlutterError(
                         code: "initialize_error",
@@ -24,7 +26,7 @@ public class ZendeskMessaging: NSObject {
                         details: nil)
                     )
                 } else {
-                    self.zendeskPlugin?.isInitialized = true
+                    self.zendeskPlugin.isInitialized = true
                     print("\(self.TAG) - initialize success")
                     flutterResult(nil)
                 }
@@ -35,7 +37,7 @@ public class ZendeskMessaging: NSObject {
 
     func invalidate() {
         Zendesk.invalidate()
-        self.zendeskPlugin?.isInitialized = false
+        self.zendeskPlugin.isInitialized = false
         print("\(self.TAG) - invalidate")
     }
     
@@ -93,7 +95,7 @@ public class ZendeskMessaging: NSObject {
             DispatchQueue.main.async {
                 switch result {
                 case .success(let user):
-                    self.zendeskPlugin?.isLoggedIn = true
+                    self.zendeskPlugin.isLoggedIn = true
                     flutterResult([
                         "id": user.id,
                         "externalId": user.externalId
@@ -116,7 +118,7 @@ public class ZendeskMessaging: NSObject {
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                    self.zendeskPlugin?.isLoggedIn = false
+                    self.zendeskPlugin.isLoggedIn = false
                     flutterResult(nil)
                 case .failure(let error):
                     print("\(self.TAG) - logout failure - \(error.localizedDescription)\n")

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -5,7 +5,7 @@ import ZendeskSDK
 public class ZendeskMessaging: NSObject {
     let TAG = "[ZendeskMessaging]"
     
-    private var zendeskPlugin: SwiftZendeskMessagingPlugin
+    private weak var zendeskPlugin: SwiftZendeskMessagingPlugin?
     private let channel: FlutterMethodChannel
 
     init(flutterPlugin: SwiftZendeskMessagingPlugin, channel: FlutterMethodChannel) {
@@ -18,7 +18,7 @@ public class ZendeskMessaging: NSObject {
         Zendesk.initialize(withChannelKey: channelKey, messagingFactory: DefaultMessagingFactory()) { result in
             DispatchQueue.main.async {
                 if case let .failure(error) = result {
-                    self.zendeskPlugin.isInitialized = false
+                    self.zendeskPlugin?.isInitialized = false
                     print("\(self.TAG) - initialize failure - \(error.localizedDescription)\n")
                     flutterResult(FlutterError(
                         code: "initialize_error",
@@ -26,7 +26,7 @@ public class ZendeskMessaging: NSObject {
                         details: nil)
                     )
                 } else {
-                    self.zendeskPlugin.isInitialized = true
+                    self.zendeskPlugin?.isInitialized = true
                     print("\(self.TAG) - initialize success")
                     flutterResult(nil)
                 }
@@ -37,7 +37,7 @@ public class ZendeskMessaging: NSObject {
 
     func invalidate() {
         Zendesk.invalidate()
-        self.zendeskPlugin.isInitialized = false
+        self.zendeskPlugin?.isInitialized = false
         print("\(self.TAG) - invalidate")
     }
     
@@ -95,7 +95,7 @@ public class ZendeskMessaging: NSObject {
             DispatchQueue.main.async {
                 switch result {
                 case .success(let user):
-                    self.zendeskPlugin.isLoggedIn = true
+                    self.zendeskPlugin?.isLoggedIn = true
                     flutterResult([
                         "id": user.id,
                         "externalId": user.externalId
@@ -118,7 +118,7 @@ public class ZendeskMessaging: NSObject {
             DispatchQueue.main.async {
                 switch result {
                 case .success:
-                    self.zendeskPlugin.isLoggedIn = false
+                    self.zendeskPlugin?.isLoggedIn = false
                     flutterResult(nil)
                 case .failure(let error):
                     print("\(self.TAG) - logout failure - \(error.localizedDescription)\n")


### PR DESCRIPTION
To align the mechanism with Android side.

- [x] Remove invoking flutter channel from Swift, use `FlutterResult` instead
- [x] Add missing flutter result call for the initialization check