### PR TITLE
🐛 fix(ios): resolve root view controller for UISceneDelegate apps

### DIFF
--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -42,7 +42,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging?.show(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
+            zendeskMessaging?.show(rootViewController: getRootViewController(), flutterResult: result)
 
         case "showConversation":
             if !isInitialized {
@@ -54,7 +54,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "invalid_argument", message: "conversationId is required", details: nil))
                 return
             }
-            zendeskMessaging?.showConversation(conversationId: conversationId, rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
+            zendeskMessaging?.showConversation(conversationId: conversationId, rootViewController: getRootViewController(), flutterResult: result)
 
         case "showConversationList":
             if !isInitialized {
@@ -62,7 +62,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging?.showConversationList(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
+            zendeskMessaging?.showConversationList(rootViewController: getRootViewController(), flutterResult: result)
 
         case "startNewConversation":
             if !isInitialized {
@@ -70,7 +70,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
                 reportNotInitializedFlutterError(result: result)
                 return
             }
-            zendeskMessaging?.startNewConversation(rootViewController: UIApplication.shared.delegate?.window??.rootViewController, flutterResult: result)
+            zendeskMessaging?.startNewConversation(rootViewController: getRootViewController(), flutterResult: result)
 
         case "loginUser":
             if !isInitialized {
@@ -232,7 +232,7 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
             }
             zendeskMessaging?.handleNotificationTap(
                 messageData,
-                rootViewController: UIApplication.shared.delegate?.window??.rootViewController
+                rootViewController: getRootViewController()
             ) { success in
                 result(nil)
             }
@@ -252,6 +252,25 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
 
     private func handleLoggedInStatus() -> Bool {
         return isLoggedIn
+    }
+
+    private func getRootViewController() -> UIViewController? {
+        // Scene-based window resolution (supports UISceneDelegate)
+        let windowScene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first(where: { $0.activationState == .foregroundActive })
+            ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first(where: { $0.activationState == .foregroundInactive })
+
+        if let windowScene = windowScene {
+            let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
+                ?? windowScene.windows.first
+            return keyWindow?.rootViewController
+        }
+
+        // Fallback for non-scene setups
+        return UIApplication.shared.delegate?.window??.rootViewController
     }
 
     private func reportNotInitializedFlutterError(result: FlutterResult) {


### PR DESCRIPTION
## Summary

Fixes #93

When the app uses `UISceneDelegate` (e.g. Flutter's default `FlutterSceneDelegate`), `UIApplication.shared.delegate?.window??.rootViewController` returns `nil` because the window is owned by the scene, not `AppDelegate`. This causes `show()`, `showConversation()`, `showConversationList()`, `startNewConversation()`, and `handleNotificationTap()` to fail with "Root view controller is nil".

## Changes

Extract a `getRootViewController()` helper in `SwiftZendeskMessagingPlugin.swift` with a scene-aware fallback chain:

1. **`foregroundActive` UIWindowScene** — primary path for normal app usage
2. **`foregroundInactive` UIWindowScene** — covers notification center / control center open
3. **Key window fallback** — if no key window found, uses the first window in the scene
4. **AppDelegate window fallback** — for legacy non-scene setups

### Affected methods (5 call sites)
- `show`
- `showConversation`
- `showConversationList`
- `startNewConversation`
- `handleNotificationTap`

## Test plan

- [x] All 129 existing tests pass
- [x] `flutter analyze` — no issues
- [x] Manual test: Scene-based iOS app (FlutterSceneDelegate) — `show()` presents correctly
- [x] Manual test: Non-scene iOS app — `show()` still works via AppDelegate fallback
- [x] Manual test: Call `show()` while notification center is open (foregroundInactive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root view controller resolution on iOS to better support modern app architecture with multiple windows and scenes, enhancing stability when displaying messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->