### PR TITLE
fix(ios): correctly hex-decode APNs token for push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.3
+
+### Bug Fixes
+
+- **iOS**: Fix push notification token conversion — correctly hex-decode APNs device token string to raw bytes instead of UTF-8 encoding (#95)
+- **Docs**: Clarify that iOS requires APNs device token (via `getAPNSToken()`), not FCM registration token
+
 ## 3.2.2
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -349,19 +349,16 @@ Future<void> setupPushNotifications() async {
   await messaging.requestPermission();
 
   // Get and register the correct token per platform
-  // - Android: FCM token
-  // - iOS: APNs device token (Zendesk iOS SDK requires APNs, not FCM)
-  String? token;
-  if (Platform.isAndroid) {
-    token = await messaging.getToken();
-  } else if (Platform.isIOS) {
-    token = await messaging.getAPNSToken();
-  }
-  if (token != null) {
-    await ZendeskMessaging.updatePushNotificationToken(token);
-  }
+  // - Android: FCM token via getToken()
+  // - iOS: APNs device token via getAPNSToken()
+  //   (Zendesk iOS SDK requires APNs token, NOT the FCM token)
+  await _registerPushToken(messaging);
 
-  // Listen for token refresh (Android only — APNs tokens rarely change)
+  // Listen for token refresh
+  // - Android: onTokenRefresh returns new FCM tokens
+  // - iOS: APNs tokens rarely change (device restore, OS update);
+  //   re-fetch via getAPNSToken() on each app launch (done above).
+  //   onTokenRefresh returns FCM tokens which are NOT usable here.
   if (Platform.isAndroid) {
     messaging.onTokenRefresh.listen((token) {
       ZendeskMessaging.updatePushNotificationToken(token);
@@ -387,9 +384,21 @@ Future<void> setupPushNotifications() async {
     await ZendeskMessaging.handleNotificationTap(message.data);
   });
 }
+
+Future<void> _registerPushToken(FirebaseMessaging messaging) async {
+  String? token;
+  if (Platform.isAndroid) {
+    token = await messaging.getToken();
+  } else if (Platform.isIOS) {
+    token = await messaging.getAPNSToken();
+  }
+  if (token != null) {
+    await ZendeskMessaging.updatePushNotificationToken(token);
+  }
+}
 ```
 
-> **Important (iOS):** The Zendesk iOS SDK uses APNs directly for push notifications, not FCM. You must pass the APNs device token via `getAPNSToken()`, not the FCM registration token from `getToken()`. Using the wrong token type will silently fail to deliver notifications.
+> **Important (iOS):** The Zendesk iOS SDK uses APNs directly for push notifications, not FCM. You must pass the APNs device token via `getAPNSToken()`, not the FCM registration token from `getToken()`. Using the wrong token type will silently fail to deliver notifications. APNs tokens rarely change, but calling `getAPNSToken()` on each app launch ensures the token stays current.
 
 ### Push Notification API
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Enable push notifications to notify users of new messages when the app is in the
 ### Usage
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
@@ -347,16 +348,25 @@ Future<void> setupPushNotifications() async {
   // Request permission
   await messaging.requestPermission();
 
-  // Get and register token
-  final token = await messaging.getToken();
+  // Get and register the correct token per platform
+  // - Android: FCM token
+  // - iOS: APNs device token (Zendesk iOS SDK requires APNs, not FCM)
+  String? token;
+  if (Platform.isAndroid) {
+    token = await messaging.getToken();
+  } else if (Platform.isIOS) {
+    token = await messaging.getAPNSToken();
+  }
   if (token != null) {
     await ZendeskMessaging.updatePushNotificationToken(token);
   }
 
-  // Listen for token refresh
-  messaging.onTokenRefresh.listen((token) {
-    ZendeskMessaging.updatePushNotificationToken(token);
-  });
+  // Listen for token refresh (Android only — APNs tokens rarely change)
+  if (Platform.isAndroid) {
+    messaging.onTokenRefresh.listen((token) {
+      ZendeskMessaging.updatePushNotificationToken(token);
+    });
+  }
 
   // Handle foreground notifications
   FirebaseMessaging.onMessage.listen((message) async {
@@ -378,6 +388,8 @@ Future<void> setupPushNotifications() async {
   });
 }
 ```
+
+> **Important (iOS):** The Zendesk iOS SDK uses APNs directly for push notifications, not FCM. You must pass the APNs device token via `getAPNSToken()`, not the FCM registration token from `getToken()`. Using the wrong token type will silently fail to deliver notifications.
 
 ### Push Notification API
 

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -435,17 +435,34 @@ public class ZendeskMessaging: NSObject {
         print("\(self.TAG) - updatePushNotificationToken: token updated")
     }
 
-    /// Update the push notification token from a string (FCM token format).
-    /// Converts the string to Data before passing to SDK.
+    /// Update the push notification token from a hex string.
+    /// The Zendesk iOS SDK requires raw APNs device token Data.
+    /// This method converts the hex string representation back to raw bytes.
     func updatePushNotificationTokenString(_ token: String) {
-        // For iOS, we typically receive Data from APNs, but if using FCM,
-        // the token comes as a string. We pass it directly to the SDK.
-        if let tokenData = token.data(using: .utf8) {
-            PushNotifications.updatePushNotificationToken(tokenData)
-            print("\(self.TAG) - updatePushNotificationTokenString: token updated")
-        } else {
-            print("\(self.TAG) - updatePushNotificationTokenString: invalid token format")
+        let hexString = token
+            .replacingOccurrences(of: "<", with: "")
+            .replacingOccurrences(of: ">", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        guard hexString.count % 2 == 0 else {
+            print("\(self.TAG) - updatePushNotificationTokenString: invalid hex token (odd length)")
+            return
         }
+
+        var data = Data()
+        var index = hexString.startIndex
+        while index < hexString.endIndex {
+            let nextIndex = hexString.index(index, offsetBy: 2)
+            guard let byte = UInt8(hexString[index..<nextIndex], radix: 16) else {
+                print("\(self.TAG) - updatePushNotificationTokenString: invalid hex character in token")
+                return
+            }
+            data.append(byte)
+            index = nextIndex
+        }
+
+        PushNotifications.updatePushNotificationToken(data)
+        print("\(self.TAG) - updatePushNotificationTokenString: token updated (\(data.count) bytes)")
     }
 
     /// Check if a push notification should be displayed by Zendesk.

--- a/lib/src/zendesk_messaging.dart
+++ b/lib/src/zendesk_messaging.dart
@@ -569,28 +569,40 @@ class ZendeskMessaging {
 
   /// Update the push notification token with Zendesk.
   ///
-  /// Call this method when you receive a new FCM token (Android) or
-  /// APNs device token (iOS) to enable push notifications.
+  /// Call this method when you receive a new push notification token
+  /// to enable push notifications.
   ///
   /// [token] The push notification token string.
-  /// - Android: FCM token from FirebaseMessaging.instance.getToken()
-  /// - iOS: APNs device token converted to string
+  /// - Android: FCM token from `FirebaseMessaging.instance.getToken()`
+  /// - iOS: **APNs device token** (hex string) from
+  ///   `FirebaseMessaging.instance.getAPNSToken()`. The Zendesk iOS SDK
+  ///   requires the native APNs token, not the FCM token.
+  ///
+  /// **Important (iOS):** You must pass the APNs device token, not the FCM
+  /// registration token. FCM tokens are not compatible with the Zendesk iOS
+  /// SDK's push notification system. Use `getAPNSToken()` instead of
+  /// `getToken()` on iOS.
   ///
   /// Throws [ArgumentError] if token is empty.
   /// Throws [PlatformException] if the update fails.
   ///
   /// Example:
   /// ```dart
-  /// // Android with firebase_messaging
-  /// final fcmToken = await FirebaseMessaging.instance.getToken();
-  /// if (fcmToken != null) {
-  ///   await ZendeskMessaging.updatePushNotificationToken(fcmToken);
-  /// }
+  /// import 'dart:io' show Platform;
   ///
-  /// // Listen for token refresh
-  /// FirebaseMessaging.instance.onTokenRefresh.listen((token) {
-  ///   ZendeskMessaging.updatePushNotificationToken(token);
-  /// });
+  /// // Get the correct token per platform
+  /// final messaging = FirebaseMessaging.instance;
+  /// String? token;
+  /// if (Platform.isAndroid) {
+  ///   token = await messaging.getToken();
+  /// } else if (Platform.isIOS) {
+  ///   // iOS requires the APNs token, not the FCM token
+  ///   final apnsToken = await messaging.getAPNSToken();
+  ///   token = apnsToken;
+  /// }
+  /// if (token != null) {
+  ///   await ZendeskMessaging.updatePushNotificationToken(token);
+  /// }
   /// ```
   static Future<void> updatePushNotificationToken(String token) async {
     if (token.isEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: zendesk_messaging
 description: >-
   Flutter plugin for Zendesk Messaging SDK. Provides in-app customer support
   messaging with multi-conversation support, real-time events, and JWT authentication.
-version: 3.2.2
+version: 3.2.3
 homepage: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging
 repository: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging
 issue_tracker: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging/issues


### PR DESCRIPTION
## Summary

Fixes #95

- **Root cause**: `updatePushNotificationTokenString` was using `.data(using: .utf8)` to convert the token string to `Data`. This encodes the hex string characters as UTF-8 bytes (e.g., `"0a"` → `[0x30, 0x61]`) instead of decoding the hex back to raw bytes (`"0a"` → `[0x0a]`). The Zendesk iOS SDK received a completely wrong token and silently failed to register for push notifications.
- **Fix**: Properly hex-decode the APNs device token string back to raw `Data` bytes before passing to `PushNotifications.updatePushNotificationToken()`.
- **Docs**: Clarify that iOS requires the **APNs device token** (via `getAPNSToken()`), not the FCM registration token from `getToken()`. Updated README example code and Dart API documentation.

## Changes

| File | Change |
|------|--------|
| `ios/Classes/ZendeskMessaging.swift` | Fix hex string → raw Data conversion |
| `lib/src/zendesk_messaging.dart` | Update API docs with iOS APNs guidance |
| `README.md` | Update push notification example with platform-specific token retrieval |
| `CHANGELOG.md` | Add 3.2.3 entry |
| `pubspec.yaml` | Bump to 3.2.3 |

## Test plan

- [x] All 129 existing unit tests pass
- [x] `flutter analyze` clean
- [ ] Manual test on real iOS device: verify push notifications arrive when agent replies in Zendesk chat
- [ ] Verify APNs token from `getAPNSToken()` is correctly registered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 3.2.3

* **Bug Fixes**
  * Fixed iOS push notification token handling to correctly process APNs device tokens as hex-encoded strings.

* **Documentation**
  * Clarified that iOS requires APNs device tokens (from `getAPNSToken()`), not FCM registration tokens.
  * Updated setup examples with platform-specific token retrieval for Android and iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->