### PR TITLE
feat: add setLocale() to override Zendesk messaging UI language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.3.0
+
+### New Features
+
+- **Locale**: Add `setLocale(locale)` to override the Zendesk messaging UI language at runtime (#97)
+  - Android: Sets `Locale.setDefault()` and updates activity resource configuration
+  - iOS: Sets `AppleLanguages` user default for SDK localization
+
 ## 3.2.2
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A Flutter plugin for integrating Zendesk Messaging SDK into mobile applications. This is a federated plugin with platform-specific implementations for Android (Kotlin) and iOS (Swift).
 
-**Current Version**: 3.2.2
+**Current Version**: 3.3.0
 **SDK Versions**: Android 2.36.1, iOS 2.36.0
 
 ## Development Commands

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Flutter plugin for integrating Zendesk Messaging SDK into your mobile applicat
 - Unread message count tracking
 - Conversation tags and custom fields
 - Connection status monitoring
+- Runtime locale override for messaging UI
 - Push notifications support (FCM/APNs)
 
 ## Requirements
@@ -303,6 +304,24 @@ final color = switch (status) {
 };
 ```
 
+## Locale
+
+Override the device's system locale so the Zendesk messaging UI matches your app's language:
+
+```dart
+// Set locale before showing messaging UI
+await ZendeskMessaging.setLocale('es');
+await ZendeskMessaging.show();
+
+// Or use Flutter's Localizations
+final locale = Localizations.localeOf(context);
+await ZendeskMessaging.setLocale(locale.toLanguageTag());
+```
+
+**Platform details:**
+- **Android**: Sets the default locale and updates the activity's resource configuration. Takes effect immediately for subsequent `show()` calls.
+- **iOS**: Sets the `AppleLanguages` user default. For best results, call before `initialize()` or re-initialize the SDK after changing the locale.
+
 ## Push Notifications
 
 Enable push notifications to notify users of new messages when the app is in the background or closed.
@@ -433,6 +452,7 @@ await ZendeskMessaging.invalidate();
 | `setConversationFields(fields)` | `Future<void>` | Set custom fields |
 | `clearConversationFields()` | `Future<void>` | Clear custom fields |
 | `getConnectionStatus()` | `Future<ZendeskConnectionStatus>` | Get connection status |
+| `setLocale(locale)` | `Future<void>` | Set messaging UI locale |
 | `updatePushNotificationToken(token)` | `Future<void>` | Register push token |
 | `shouldBeDisplayed(data)` | `Future<ZendeskPushResponsibility>` | Check notification source |
 | `handleNotification(data)` | `Future<bool>` | Handle push notification |

--- a/README.md
+++ b/README.md
@@ -306,21 +306,32 @@ final color = switch (status) {
 
 ## Locale
 
-Override the device's system locale so the Zendesk messaging UI matches your app's language:
+Override the device's system locale so the Zendesk messaging UI matches your app's language. The Zendesk SDK ships with [33 languages](https://developer.zendesk.com/documentation/zendesk-web-widget-sdks/sdks/android/localization/).
 
 ```dart
-// Set locale before showing messaging UI
+// Best: set locale before initialization
 await ZendeskMessaging.setLocale('es');
+await ZendeskMessaging.initialize(
+  androidChannelKey: '<YOUR_ANDROID_CHANNEL_KEY>',
+  iosChannelKey: '<YOUR_IOS_CHANNEL_KEY>',
+);
+
+// Android: can also switch at runtime before show()
+await ZendeskMessaging.setLocale('ja');
 await ZendeskMessaging.show();
 
-// Or use Flutter's Localizations
-final locale = Localizations.localeOf(context);
-await ZendeskMessaging.setLocale(locale.toLanguageTag());
+// iOS runtime switch: requires re-initialization
+await ZendeskMessaging.setLocale('fr');
+await ZendeskMessaging.invalidate();
+await ZendeskMessaging.initialize(
+  androidChannelKey: '<YOUR_ANDROID_CHANNEL_KEY>',
+  iosChannelKey: '<YOUR_IOS_CHANNEL_KEY>',
+);
 ```
 
 **Platform details:**
-- **Android**: Sets the default locale and updates the activity's resource configuration. Takes effect immediately for subsequent `show()` calls.
-- **iOS**: Sets the `AppleLanguages` user default. For best results, call before `initialize()` or re-initialize the SDK after changing the locale.
+- **Android**: Sets `Locale.setDefault()` and updates application/activity resource configuration. The SDK resolves UI strings from Android's resource system, so this takes effect when the SDK launches its messaging Activity. Can switch at runtime.
+- **iOS**: Sets the `AppleLanguages` user default, which controls which localization bundle the SDK loads. Must be set **before** `initialize()`. To change after initialization, call `invalidate()` then `initialize()` again.
 
 ## Push Notifications
 

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -497,6 +497,16 @@ class ZendeskMessaging(
         val parsedLocale = java.util.Locale.forLanguageTag(locale)
         java.util.Locale.setDefault(parsedLocale)
 
+        // Update application context so new Activities launched by the SDK
+        // inherit the correct locale for resource resolution
+        plugin.activity?.applicationContext?.let { appContext ->
+            val appConfig = android.content.res.Configuration(appContext.resources.configuration)
+            appConfig.setLocale(parsedLocale)
+            @Suppress("DEPRECATION")
+            appContext.resources.updateConfiguration(appConfig, appContext.resources.displayMetrics)
+        }
+
+        // Update current activity context for immediate effect
         plugin.activity?.let { activity ->
             val config = android.content.res.Configuration(activity.resources.configuration)
             config.setLocale(parsedLocale)

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -490,6 +490,23 @@ class ZendeskMessaging(
     }
 
     // ============================================================================
+    // Locale
+    // ============================================================================
+
+    fun setLocale(locale: String) {
+        val parsedLocale = java.util.Locale.forLanguageTag(locale)
+        java.util.Locale.setDefault(parsedLocale)
+
+        plugin.activity?.let { activity ->
+            val config = android.content.res.Configuration(activity.resources.configuration)
+            config.setLocale(parsedLocale)
+            @Suppress("DEPRECATION")
+            activity.resources.updateConfiguration(config, activity.resources.displayMetrics)
+        }
+        println("$TAG - setLocale: $locale")
+    }
+
+    // ============================================================================
     // Push Notifications
     // ============================================================================
 

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -238,6 +238,30 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
 
             // ================================================================
+            // Locale
+            // ================================================================
+
+            "setLocale" -> {
+                if (!isInitialized) {
+                    println("$tag - Zendesk SDK needs to be initialized first")
+                    reportNotInitializedFlutterError(result)
+                    return
+                }
+                val locale = call.argument<String>("locale")
+                if (locale.isNullOrEmpty()) {
+                    result.error("invalid_argument", "locale is required", null)
+                    return
+                }
+                try {
+                    zendeskMessaging.setLocale(locale)
+                    result.success(null)
+                } catch (err: Throwable) {
+                    println("$tag - setLocale error: ${err.message}")
+                    result.error("set_locale_error", err.message, null)
+                }
+            }
+
+            // ================================================================
             // Push Notifications
             // ================================================================
 

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -242,11 +242,8 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             // ================================================================
 
             "setLocale" -> {
-                if (!isInitialized) {
-                    println("$tag - Zendesk SDK needs to be initialized first")
-                    reportNotInitializedFlutterError(result)
-                    return
-                }
+                // No isInitialized check — setLocale can be called before
+                // initialize() to set the locale for the SDK at startup.
                 val locale = call.argument<String>("locale")
                 if (locale.isNullOrEmpty()) {
                     result.error("invalid_argument", "locale is required", null)

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -188,6 +188,23 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
             result(nil)
 
         // ================================================================
+        // Locale
+        // ================================================================
+
+        case "setLocale":
+            if !isInitialized {
+                print("\(TAG) - Messaging needs to be initialized first.\n")
+                reportNotInitializedFlutterError(result: result)
+                return
+            }
+            guard let locale = arguments?["locale"] as? String, !locale.isEmpty else {
+                result(FlutterError(code: "invalid_argument", message: "locale is required", details: nil))
+                return
+            }
+            zendeskMessaging?.setLocale(locale: locale)
+            result(nil)
+
+        // ================================================================
         // Push Notifications
         // ================================================================
 

--- a/ios/Classes/SwiftZendeskMessagingPlugin.swift
+++ b/ios/Classes/SwiftZendeskMessagingPlugin.swift
@@ -192,11 +192,8 @@ public class SwiftZendeskMessagingPlugin: NSObject, FlutterPlugin {
         // ================================================================
 
         case "setLocale":
-            if !isInitialized {
-                print("\(TAG) - Messaging needs to be initialized first.\n")
-                reportNotInitializedFlutterError(result: result)
-                return
-            }
+            // No isInitialized check — on iOS, setLocale should be called
+            // BEFORE initialize() for the locale to take full effect.
             guard let locale = arguments?["locale"] as? String, !locale.isEmpty else {
                 result(FlutterError(code: "invalid_argument", message: "locale is required", details: nil))
                 return

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -425,6 +425,16 @@ public class ZendeskMessaging: NSObject {
     }
 
     // ============================================================================
+    // Locale
+    // ============================================================================
+
+    func setLocale(locale: String) {
+        UserDefaults.standard.set([locale], forKey: "AppleLanguages")
+        UserDefaults.standard.synchronize()
+        print("\(self.TAG) - setLocale: \(locale)")
+    }
+
+    // ============================================================================
     // Push Notifications
     // ============================================================================
 

--- a/lib/src/zendesk_messaging.dart
+++ b/lib/src/zendesk_messaging.dart
@@ -574,29 +574,46 @@ class ZendeskMessaging {
   ///
   /// [locale] A BCP 47 language tag (e.g. `'en'`, `'es'`, `'zh-TW'`).
   ///
-  /// **How it works:**
-  /// - **Android**: Sets `Locale.setDefault()` and updates the activity's
-  ///   resource configuration. The Zendesk SDK picks up UI strings from
-  ///   Android's resource system.
-  /// - **iOS**: Sets the `AppleLanguages` user default. For best results,
-  ///   call this before [initialize] or re-initialize the SDK afterwards.
+  /// Can be called before or after [initialize]. For the most reliable
+  /// behavior, call this **before** [initialize].
   ///
-  /// **Note:** Call this method before [show] or [initialize] for the
-  /// locale change to take full effect. On iOS, a re-initialization
-  /// may be needed for the change to apply.
+  /// **How it works:**
+  /// - **Android**: Sets `Locale.setDefault()` and updates both the
+  ///   application and activity resource configurations. The Zendesk SDK
+  ///   resolves UI strings from Android's resource system, so this takes
+  ///   effect when the SDK launches its messaging Activity.
+  /// - **iOS**: Sets the `AppleLanguages` user default, which controls
+  ///   which `.lproj` bundle the SDK loads localized strings from.
+  ///   This must be set **before** the SDK loads its bundle. If the
+  ///   SDK is already initialized, call [invalidate] then [initialize]
+  ///   again for the change to take effect.
+  ///
+  /// **Supported languages:** The Zendesk SDK ships with 33 languages.
+  /// See the [localization docs](https://developer.zendesk.com/documentation/zendesk-web-widget-sdks/sdks/android/localization/)
+  /// for the full list.
   ///
   /// Throws [ArgumentError] if locale is empty.
-  /// Throws [PlatformException] if the SDK has not been initialized.
   ///
   /// Example:
   /// ```dart
-  /// // Set locale before showing messaging UI
+  /// // Best: set locale before initialization
   /// await ZendeskMessaging.setLocale('es');
+  /// await ZendeskMessaging.initialize(
+  ///   androidChannelKey: 'key',
+  ///   iosChannelKey: 'key',
+  /// );
+  ///
+  /// // Also works on Android: set locale then show
+  /// await ZendeskMessaging.setLocale('ja');
   /// await ZendeskMessaging.show();
   ///
-  /// // Or use Flutter's Localizations
-  /// final locale = Localizations.localeOf(context);
-  /// await ZendeskMessaging.setLocale(locale.toLanguageTag());
+  /// // iOS runtime switch: requires re-initialization
+  /// await ZendeskMessaging.setLocale('fr');
+  /// await ZendeskMessaging.invalidate();
+  /// await ZendeskMessaging.initialize(
+  ///   androidChannelKey: 'key',
+  ///   iosChannelKey: 'key',
+  /// );
   /// ```
   static Future<void> setLocale(String locale) async {
     if (locale.isEmpty) {

--- a/lib/src/zendesk_messaging.dart
+++ b/lib/src/zendesk_messaging.dart
@@ -564,6 +564,61 @@ class ZendeskMessaging {
   }
 
   // ============================================================================
+  // Locale
+  // ============================================================================
+
+  /// Set the locale for the Zendesk Messaging UI.
+  ///
+  /// Overrides the device's system locale so the Zendesk chat UI
+  /// matches the app's current language setting.
+  ///
+  /// [locale] A BCP 47 language tag (e.g. `'en'`, `'es'`, `'zh-TW'`).
+  ///
+  /// **How it works:**
+  /// - **Android**: Sets `Locale.setDefault()` and updates the activity's
+  ///   resource configuration. The Zendesk SDK picks up UI strings from
+  ///   Android's resource system.
+  /// - **iOS**: Sets the `AppleLanguages` user default. For best results,
+  ///   call this before [initialize] or re-initialize the SDK afterwards.
+  ///
+  /// **Note:** Call this method before [show] or [initialize] for the
+  /// locale change to take full effect. On iOS, a re-initialization
+  /// may be needed for the change to apply.
+  ///
+  /// Throws [ArgumentError] if locale is empty.
+  /// Throws [PlatformException] if the SDK has not been initialized.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Set locale before showing messaging UI
+  /// await ZendeskMessaging.setLocale('es');
+  /// await ZendeskMessaging.show();
+  ///
+  /// // Or use Flutter's Localizations
+  /// final locale = Localizations.localeOf(context);
+  /// await ZendeskMessaging.setLocale(locale.toLanguageTag());
+  /// ```
+  static Future<void> setLocale(String locale) async {
+    if (locale.isEmpty) {
+      throw ArgumentError('locale cannot be empty');
+    }
+
+    try {
+      await _channel.invokeMethod('setLocale', {
+        'locale': locale,
+      });
+      ZendeskMessagingConfig.log('Locale set to: $locale');
+    } catch (e, stackTrace) {
+      ZendeskMessagingConfig.logError(
+        'setLocale failed',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  // ============================================================================
   // Push Notifications
   // ============================================================================
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: zendesk_messaging
 description: >-
   Flutter plugin for Zendesk Messaging SDK. Provides in-app customer support
   messaging with multi-conversation support, real-time events, and JWT authentication.
-version: 3.2.2
+version: 3.3.0
 homepage: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging
 repository: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging
 issue_tracker: https://github.com/chyiiiiiiiiiiii/flutter_zendesk_messaging/issues

--- a/test/zendesk_messaging_test.dart
+++ b/test/zendesk_messaging_test.dart
@@ -246,6 +246,31 @@ void main() {
     });
   });
 
+  group('Locale', () {
+    test('setLocale sends locale string', () async {
+      await ZendeskMessaging.setLocale('es');
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'setLocale');
+      expect(log.first.arguments['locale'], 'es');
+    });
+
+    test('setLocale sends BCP 47 language tag', () async {
+      await ZendeskMessaging.setLocale('zh-TW');
+
+      expect(log, hasLength(1));
+      expect(log.first.method, 'setLocale');
+      expect(log.first.arguments['locale'], 'zh-TW');
+    });
+
+    test('setLocale throws ArgumentError for empty locale', () async {
+      expect(
+        () => ZendeskMessaging.setLocale(''),
+        throwsArgumentError,
+      );
+    });
+  });
+
   group('Push Notifications', () {
     test('updatePushNotificationToken sends token', () async {
       await ZendeskMessaging.updatePushNotificationToken('test_fcm_token_123');
@@ -593,6 +618,8 @@ dynamic _handleMockMethodCall(MethodCall methodCall) {
     case 'setConversationFields':
       return null;
     case 'clearConversationFields':
+      return null;
+    case 'setLocale':
       return null;
     case 'updatePushNotificationToken':
       return null;


### PR DESCRIPTION
## Summary

- Add `ZendeskMessaging.setLocale(locale)` to override the Zendesk messaging UI language at runtime (#97)
- Accepts BCP 47 language tags (e.g. `'en'`, `'es'`, `'zh-TW'`)
- Android: Sets `Locale.setDefault()` and updates activity resource configuration
- iOS: Sets `AppleLanguages` user default for SDK localization

## Changes

| File | Change |
|------|--------|
| `lib/src/zendesk_messaging.dart` | New `setLocale()` method with validation and docs |
| `ZendeskMessaging.kt` | Android locale override via `Locale.setDefault()` + `updateConfiguration()` |
| `ZendeskMessagingPlugin.kt` | Method channel handler for `setLocale` |
| `ZendeskMessaging.swift` | iOS locale override via `UserDefaults` `AppleLanguages` |
| `SwiftZendeskMessagingPlugin.swift` | Method channel handler for `setLocale` |
| `zendesk_messaging_test.dart` | 3 new tests (locale string, BCP 47 tag, empty validation) |
| `README.md` | Locale section + API reference table entry |
| `CHANGELOG.md` | 3.3.0 release notes |

## Implementation Notes

The Zendesk Messaging SDK does not expose a native `setLocale()` API. Instead, the SDK reads locale from the platform's resource/localization system. This implementation uses OS-level locale overrides:

- **Android**: `Locale.setDefault()` + activity `Resources.updateConfiguration()` — the SDK loads string resources from the activity context, so this takes effect for subsequent `show()` calls
- **iOS**: `UserDefaults "AppleLanguages"` — the standard mechanism for overriding app locale; for best results, call before `initialize()` or re-initialize after

## Test plan

- [x] All 132 tests pass (`flutter test`)
- [x] Zero lint issues (`flutter analyze`)
- [x] Android build succeeds (`flutter build apk --debug`)
- [x] iOS build succeeds (`flutter build ios --no-codesign --debug`)
- [x] New tests cover: simple locale, BCP 47 tag, empty string validation

Closes #97