### PR TITLE
fix: repair iOS APNs token encoding + Android background push delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
-## Unreleased — Flexii fork (based on 3.2.2)
-
-Maintained at github.com/yiichenflexii/flutter_zendesk_messaging, branch
-`fix/ios-apns-token-hex-parsing`. Pinned by the Flexii worker app until these
-fixes are upstreamed.
+## Unreleased
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## Unreleased — Flexii fork (based on 3.2.2)
+
+Maintained at github.com/yiichenflexii/flutter_zendesk_messaging, branch
+`fix/ios-apns-token-hex-parsing`. Pinned by the Flexii worker app until these
+fixes are upstreamed.
+
+### Bug Fixes
+
+- **iOS**: Parse the APNs device token as hex before forwarding to
+  `PushNotifications.updatePushNotificationToken`. The previous code used
+  `token.data(using: .utf8)`, which produced the UTF-8 bytes of the hex
+  string instead of the 32-byte device token, so Zendesk registered a
+  malformed token and never delivered iOS push.
+- **Android**: Use the application context (stored in `onAttachedToEngine`)
+  for `handleNotification` instead of the Activity. The Activity is null in a
+  background isolate / terminated state, so the previous code bailed with
+  `no_context` and background pushes never displayed.
+  `PushNotifications.displayNotification` only needs a `Context`.
+- **Android**: Guard `initialize` against a null Activity to return a clean
+  error instead of a `NullPointerException`. Push display does not require
+  `initialize`; it uses `shouldBeDisplayed` / `handleNotification`.
+
 ## 3.2.2
 
 ### Bug Fixes

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessaging.kt
@@ -312,8 +312,21 @@ class ZendeskMessaging(
 
     fun initialize(channelKey: String, result: MethodChannel.Result) {
         println("$TAG - Channel Key - $channelKey")
+        // Zendesk.initialize requires an Activity. Guard against a null
+        // Activity (background isolate / terminated state) so callers get a
+        // clean error instead of a NullPointerException. Push display does
+        // not need initialize — use shouldBeDisplayed/handleNotification.
+        val currentActivity = plugin.activity ?: run {
+            println("$TAG - initialize skipped: no Activity in this context")
+            result.error(
+                "no_activity",
+                "Zendesk.initialize requires an Activity and cannot run without one",
+                null,
+            )
+            return
+        }
         Zendesk.initialize(
-            plugin.activity!!,
+            currentActivity,
             channelKey,
             successCallback = { value ->
                 plugin.isInitialized = true

--- a/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
+++ b/android/src/main/kotlin/com/chyiiiiiiiiiiiiii/zendesk_messaging/ZendeskMessagingPlugin.kt
@@ -1,6 +1,7 @@
 package com.chyiiiiiiiiiiiiii.zendesk_messaging
 
 import android.app.Activity
+import android.content.Context
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -16,12 +17,14 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var zendeskMessaging: ZendeskMessaging
 
     var activity: Activity? = null
+    var applicationContext: Context? = null
     var isInitialized: Boolean = false
     var isLoggedIn: Boolean = false
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "zendesk_messaging")
         channel.setMethodCallHandler(this)
+        applicationContext = flutterPluginBinding.applicationContext
         zendeskMessaging = ZendeskMessaging(this, channel)
     }
 
@@ -287,8 +290,12 @@ class ZendeskMessagingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                         result.error("invalid_argument", "messageData is required", null)
                         return
                     }
-                    val context = activity ?: run {
-                        result.error("no_context", "Activity context is null", null)
+                    // Prefer the application context so notifications can be
+                    // displayed from a background isolate / terminated state
+                    // where no Activity is attached. PushNotifications
+                    // .displayNotification only needs a Context, not an Activity.
+                    val context = applicationContext ?: activity ?: run {
+                        result.error("no_context", "No context available", null)
                         return
                     }
                     // Convert Map<String, Any> to Map<String, String>

--- a/ios/Classes/ZendeskMessaging.swift
+++ b/ios/Classes/ZendeskMessaging.swift
@@ -435,17 +435,28 @@ public class ZendeskMessaging: NSObject {
         print("\(self.TAG) - updatePushNotificationToken: token updated")
     }
 
-    /// Update the push notification token from a string (FCM token format).
-    /// Converts the string to Data before passing to SDK.
+    /// Update the push notification token from a hex string (APNs format).
+    /// The Flutter side should pass the APNs device token as a hex string,
+    /// not the FCM token. Use `FirebaseMessaging.instance.getAPNSToken()`.
     func updatePushNotificationTokenString(_ token: String) {
-        // For iOS, we typically receive Data from APNs, but if using FCM,
-        // the token comes as a string. We pass it directly to the SDK.
-        if let tokenData = token.data(using: .utf8) {
-            PushNotifications.updatePushNotificationToken(tokenData)
-            print("\(self.TAG) - updatePushNotificationTokenString: token updated")
-        } else {
-            print("\(self.TAG) - updatePushNotificationTokenString: invalid token format")
+        let hex = token.hasPrefix("0x") ? String(token.dropFirst(2)) : token
+        guard hex.count.isMultiple(of: 2) else {
+            print("\(self.TAG) - updatePushNotificationTokenString: token length must be even hex")
+            return
         }
+        var data = Data(capacity: hex.count / 2)
+        var idx = hex.startIndex
+        while idx < hex.endIndex {
+            let next = hex.index(idx, offsetBy: 2)
+            guard let byte = UInt8(hex[idx..<next], radix: 16) else {
+                print("\(self.TAG) - updatePushNotificationTokenString: invalid hex char")
+                return
+            }
+            data.append(byte)
+            idx = next
+        }
+        PushNotifications.updatePushNotificationToken(data)
+        print("\(self.TAG) - updatePushNotificationTokenString: token updated (\(data.count) bytes)")
     }
 
     /// Check if a push notification should be displayed by Zendesk.


### PR DESCRIPTION
Fixes #95

## Summary

Three focused fixes that, together, make Zendesk push notifications actually
deliver on a real integration. All three are independent (iOS Swift vs Android
Kotlin) and touch different platform code.

### 1. iOS — parse APNs token as hex (not UTF-8)

`updatePushNotificationTokenString` called `token.data(using: .utf8)`, which
produced the UTF-8 bytes of the **hex characters** rather than the 32-byte
APNs device token. Zendesk registered a malformed token with APNs and never
delivered iOS push. Now parses the input as hex (with optional `0x` prefix),
guards odd-length / non-hex input, and forwards the real bytes to
`PushNotifications.updatePushNotificationToken(_:)`.

### 2. Android — use application context for background display

`handleNotification` used the Activity, which is **null in a background
isolate / terminated state**, so the previous code bailed with `no_context`
and background pushes never displayed. Now uses the application context
stored in `onAttachedToEngine`. `PushNotifications.displayNotification` only
needs a `Context`.

### 3. Android — guard `initialize` against null Activity

`Zendesk.initialize` NPE'd when no Activity was attached. Now returns a clean
error instead. Push display does not require `initialize` — it uses
`shouldBeDisplayed` / `handleNotification`.

## Relationship to #96

#96 independently diagnoses and fixes the same iOS hex-decoding root cause (and
also updates the Dart side + README). This PR's iOS fix overlaps with it — if
#96 is the preferred iOS fix, the iOS commit here can be dropped and this PR
rebased to the two Android-only fixes, which #96 does not cover. Happy to go
whichever way suits the maintainer.

For the iOS portion of #95: I independently verified the hex fix end-to-end —
Zendesk push received on a physical device via a TestFlight (production-signed)
build, with the native log showing
`updatePushNotificationTokenString: token updated (32 bytes)`.

## Verification status

Both platforms verified end-to-end on physical devices.

- **iOS hex token fix — verified.** Zendesk push received on a physical
  device via a TestFlight (production-signed) build. Native log shows
  `updatePushNotificationTokenString: token updated (32 bytes)`.
- **Android fixes — verified.** Foreground and background push deliver on a
  Redmi (MIUI), including repeated foreground/background switching. An Oppo
  (ColorOS) delays/drops background push under repeated switching on the same
  build — this is the well-known aggressive-OEM (Doze / standby-bucket)
  throttling, **not** a regression in these fixes (same build is reliable on
  the Redmi and on stock Android).

## Test plan

- [x] iOS: `getAPNSToken()` hex string forwarded as 32 bytes; Zendesk push
  received on a physical TestFlight device
- [x] iOS: `0x`-prefixed token parses correctly; odd-length / non-hex rejected
  with a log line
- [x] Android: background/terminated push displays via the application context
- [x] Android: `initialize` with no Activity returns a clean error, no NPE