### PR TITLE
docs: use APNs token on iOS in push notification examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
   error instead of a `NullPointerException`. Push display does not require
   `initialize`; it uses `shouldBeDisplayed` / `handleNotification`.
 
+### Documentation
+
+- Correct the push notification token usage in all README translations and the
+  `updatePushNotificationToken` API doc. On iOS, pass the APNs device token
+  from `getAPNSToken()`, not the FCM token from `getToken()` — using the FCM
+  token on iOS silently fails to deliver push. Token retrieval is now split per
+  platform, and `onTokenRefresh` is guarded to Android (iOS APNs tokens are
+  re-fetched on launch).
+
 ## 3.2.2
 
 ### Bug Fixes

--- a/README.es.md
+++ b/README.es.md
@@ -206,11 +206,18 @@ await ZendeskMessaging.clearConversationFields();
 ## Notificaciones Push
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
-// Registrar token de push
-final token = await FirebaseMessaging.instance.getToken();
+// Registra el token de push correcto según la plataforma
+// - Android: token FCM mediante getToken()
+// - iOS: token de dispositivo APNs mediante getAPNSToken()
+//   (el SDK de iOS de Zendesk requiere el token APNs, NO el token FCM)
+final messaging = FirebaseMessaging.instance;
+final token = Platform.isIOS
+    ? await messaging.getAPNSToken()
+    : await messaging.getToken();
 if (token != null) {
   await ZendeskMessaging.updatePushNotificationToken(token);
 }
@@ -223,6 +230,8 @@ FirebaseMessaging.onMessage.listen((message) async {
   }
 });
 ```
+
+> **Importante (iOS):** El SDK de iOS de Zendesk usa APNs directamente para las notificaciones push, no FCM. Debes pasar el token de dispositivo APNs mediante `getAPNSToken()`, no el token de registro FCM de `getToken()`. Usar el tipo de token incorrecto hará que las notificaciones fallen de forma silenciosa.
 
 ## Referencia de la API
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -166,11 +166,18 @@ await ZendeskMessaging.listenUnreadMessages();
 ## プッシュ通知
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
-// プッシュトークンを登録します
-final token = await FirebaseMessaging.instance.getToken();
+// プラットフォームに応じて正しいトークンを登録します
+// - Android: getToken() で取得する FCM トークン
+// - iOS: getAPNSToken() で取得する APNs デバイストークン
+//   （Zendesk iOS SDK は FCM ではなく APNs トークンが必要です）
+final messaging = FirebaseMessaging.instance;
+final token = Platform.isIOS
+    ? await messaging.getAPNSToken()
+    : await messaging.getToken();
 if (token != null) {
   await ZendeskMessaging.updatePushNotificationToken(token);
 }
@@ -183,6 +190,8 @@ FirebaseMessaging.onMessage.listen((message) async {
   }
 });
 ```
+
+> **重要 (iOS):** Zendesk iOS SDK はプッシュ通知に FCM ではなく APNs を直接使用します。`getToken()` の FCM 登録トークンではなく、`getAPNSToken()` の APNs デバイストークンを渡す必要があります。誤ったトークンを渡すと、通知は何も表示されずに失敗します。
 
 ## APIリファレンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -166,11 +166,18 @@ await ZendeskMessaging.listenUnreadMessages();
 ## 푸시 알림
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
-// 푸시 토큰 등록
-final token = await FirebaseMessaging.instance.getToken();
+// 플랫폼에 맞는 올바른 토큰을 등록합니다
+// - Android: getToken()으로 가져온 FCM 토큰
+// - iOS: getAPNSToken()으로 가져온 APNs 기기 토큰
+//   (Zendesk iOS SDK는 FCM이 아닌 APNs 토큰이 필요합니다)
+final messaging = FirebaseMessaging.instance;
+final token = Platform.isIOS
+    ? await messaging.getAPNSToken()
+    : await messaging.getToken();
 if (token != null) {
   await ZendeskMessaging.updatePushNotificationToken(token);
 }
@@ -183,6 +190,8 @@ FirebaseMessaging.onMessage.listen((message) async {
   }
 });
 ```
+
+> **중요 (iOS):** Zendesk iOS SDK는 푸시 알림에 FCM이 아닌 APNs를 직접 사용합니다. `getToken()`의 FCM 등록 토큰이 아니라 `getAPNSToken()`의 APNs 기기 토큰을 전달해야 합니다. 잘못된 토큰 유형을 사용하면 알림이 표시되지 않고 조용히 실패합니다.
 
 ## API 참조
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Enable push notifications to notify users of new messages when the app is in the
 ### Usage
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
@@ -347,16 +348,22 @@ Future<void> setupPushNotifications() async {
   // Request permission
   await messaging.requestPermission();
 
-  // Get and register token
-  final token = await messaging.getToken();
-  if (token != null) {
-    await ZendeskMessaging.updatePushNotificationToken(token);
-  }
+  // Get and register the correct token per platform
+  // - Android: FCM token via getToken()
+  // - iOS: APNs device token via getAPNSToken()
+  //   (Zendesk iOS SDK requires APNs token, NOT the FCM token)
+  await _registerPushToken(messaging);
 
   // Listen for token refresh
-  messaging.onTokenRefresh.listen((token) {
-    ZendeskMessaging.updatePushNotificationToken(token);
-  });
+  // - Android: onTokenRefresh returns new FCM tokens
+  // - iOS: APNs tokens rarely change (device restore, OS update);
+  //   re-fetch via getAPNSToken() on each app launch (done above).
+  //   onTokenRefresh returns FCM tokens which are NOT usable here.
+  if (Platform.isAndroid) {
+    messaging.onTokenRefresh.listen((token) {
+      ZendeskMessaging.updatePushNotificationToken(token);
+    });
+  }
 
   // Handle foreground notifications
   FirebaseMessaging.onMessage.listen((message) async {
@@ -377,7 +384,21 @@ Future<void> setupPushNotifications() async {
     await ZendeskMessaging.handleNotificationTap(message.data);
   });
 }
+
+Future<void> _registerPushToken(FirebaseMessaging messaging) async {
+  String? token;
+  if (Platform.isAndroid) {
+    token = await messaging.getToken();
+  } else if (Platform.isIOS) {
+    token = await messaging.getAPNSToken();
+  }
+  if (token != null) {
+    await ZendeskMessaging.updatePushNotificationToken(token);
+  }
+}
 ```
+
+> **Important (iOS):** The Zendesk iOS SDK uses APNs directly for push notifications, not FCM. You must pass the APNs device token via `getAPNSToken()`, not the FCM registration token from `getToken()`. Using the wrong token type will silently fail to deliver notifications. APNs tokens rarely change, but calling `getAPNSToken()` on each app launch ensures the token stays current.
 
 ### Push Notification API
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -206,11 +206,18 @@ await ZendeskMessaging.clearConversationFields();
 ## Notificações Push
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
-// Registrar token de push
-final token = await FirebaseMessaging.instance.getToken();
+// Registra o token de push correto de acordo com a plataforma
+// - Android: token FCM via getToken()
+// - iOS: token de dispositivo APNs via getAPNSToken()
+//   (o SDK iOS do Zendesk exige o token APNs, NÃO o token FCM)
+final messaging = FirebaseMessaging.instance;
+final token = Platform.isIOS
+    ? await messaging.getAPNSToken()
+    : await messaging.getToken();
 if (token != null) {
   await ZendeskMessaging.updatePushNotificationToken(token);
 }
@@ -223,6 +230,8 @@ FirebaseMessaging.onMessage.listen((message) async {
   }
 });
 ```
+
+> **Importante (iOS):** O SDK iOS do Zendesk usa APNs diretamente para notificações push, não FCM. Você deve passar o token de dispositivo APNs via `getAPNSToken()`, não o token de registro FCM de `getToken()`. Usar o tipo de token errado fará as notificações falharem silenciosamente.
 
 ## Referência da API
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -338,6 +338,7 @@ final color = switch (status) {
 ### 使用方法
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
@@ -347,16 +348,22 @@ Future<void> setupPushNotifications() async {
   // 请求权限
   await messaging.requestPermission();
 
-  // 获取并注册 token
-  final token = await messaging.getToken();
-  if (token != null) {
-    await ZendeskMessaging.updatePushNotificationToken(token);
-  }
+  // 按平台获取并注册正确的 token
+  // - Android：通过 getToken() 获取 FCM token
+  // - iOS：通过 getAPNSToken() 获取 APNs device token
+  //   （Zendesk iOS SDK 需要 APNs token，而非 FCM token）
+  await _registerPushToken(messaging);
 
   // 监听 token 刷新
-  messaging.onTokenRefresh.listen((token) {
-    ZendeskMessaging.updatePushNotificationToken(token);
-  });
+  // - Android：onTokenRefresh 会返回新的 FCM token
+  // - iOS：APNs token 很少改变（设备还原、系统更新）；
+  //   每次启动 app 时通过 getAPNSToken() 重新获取（上方已处理）。
+  //   onTokenRefresh 返回的是 FCM token，此处不适用。
+  if (Platform.isAndroid) {
+    messaging.onTokenRefresh.listen((token) {
+      ZendeskMessaging.updatePushNotificationToken(token);
+    });
+  }
 
   // 处理前台通知
   FirebaseMessaging.onMessage.listen((message) async {
@@ -377,7 +384,21 @@ Future<void> setupPushNotifications() async {
     await ZendeskMessaging.handleNotificationTap(message.data);
   });
 }
+
+Future<void> _registerPushToken(FirebaseMessaging messaging) async {
+  String? token;
+  if (Platform.isAndroid) {
+    token = await messaging.getToken();
+  } else if (Platform.isIOS) {
+    token = await messaging.getAPNSToken();
+  }
+  if (token != null) {
+    await ZendeskMessaging.updatePushNotificationToken(token);
+  }
+}
 ```
+
+> **重要（iOS）：** Zendesk iOS SDK 直接使用 APNs 进行推送，而非 FCM。你必须通过 `getAPNSToken()` 传入 APNs device token，而不是 `getToken()` 返回的 FCM registration token。传入错误的 token 类型会导致推送静默失败。APNs token 很少改变，但每次启动 app 时调用 `getAPNSToken()` 可确保 token 保持最新。
 
 ### 推送通知 API
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -338,6 +338,7 @@ final color = switch (status) {
 ### 使用方式
 
 ```dart
+import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:zendesk_messaging/zendesk_messaging.dart';
 
@@ -347,16 +348,22 @@ Future<void> setupPushNotifications() async {
   // 請求權限
   await messaging.requestPermission();
 
-  // 取得並註冊 token
-  final token = await messaging.getToken();
-  if (token != null) {
-    await ZendeskMessaging.updatePushNotificationToken(token);
-  }
+  // 依平台取得並註冊正確的 token
+  // - Android：透過 getToken() 取得 FCM token
+  // - iOS：透過 getAPNSToken() 取得 APNs device token
+  //   （Zendesk iOS SDK 需要 APNs token，而非 FCM token）
+  await _registerPushToken(messaging);
 
   // 監聽 token 重新整理
-  messaging.onTokenRefresh.listen((token) {
-    ZendeskMessaging.updatePushNotificationToken(token);
-  });
+  // - Android：onTokenRefresh 會回傳新的 FCM token
+  // - iOS：APNs token 很少改變（裝置還原、OS 更新）；
+  //   每次啟動 app 時透過 getAPNSToken() 重新取得（上方已處理）。
+  //   onTokenRefresh 回傳的是 FCM token，此處不適用。
+  if (Platform.isAndroid) {
+    messaging.onTokenRefresh.listen((token) {
+      ZendeskMessaging.updatePushNotificationToken(token);
+    });
+  }
 
   // 處理前景通知
   FirebaseMessaging.onMessage.listen((message) async {
@@ -377,7 +384,21 @@ Future<void> setupPushNotifications() async {
     await ZendeskMessaging.handleNotificationTap(message.data);
   });
 }
+
+Future<void> _registerPushToken(FirebaseMessaging messaging) async {
+  String? token;
+  if (Platform.isAndroid) {
+    token = await messaging.getToken();
+  } else if (Platform.isIOS) {
+    token = await messaging.getAPNSToken();
+  }
+  if (token != null) {
+    await ZendeskMessaging.updatePushNotificationToken(token);
+  }
+}
 ```
+
+> **重要（iOS）：** Zendesk iOS SDK 直接使用 APNs 進行推播，而非 FCM。你必須透過 `getAPNSToken()` 傳入 APNs device token，而不是 `getToken()` 回傳的 FCM registration token。傳入錯誤的 token 類型會導致推播靜默失敗。APNs token 很少改變，但每次啟動 app 時呼叫 `getAPNSToken()` 可確保 token 維持最新。
 
 ### 推播通知 API
 

--- a/lib/src/zendesk_messaging.dart
+++ b/lib/src/zendesk_messaging.dart
@@ -569,28 +569,40 @@ class ZendeskMessaging {
 
   /// Update the push notification token with Zendesk.
   ///
-  /// Call this method when you receive a new FCM token (Android) or
-  /// APNs device token (iOS) to enable push notifications.
+  /// Call this method when you receive a new push notification token
+  /// to enable push notifications.
   ///
   /// [token] The push notification token string.
-  /// - Android: FCM token from FirebaseMessaging.instance.getToken()
-  /// - iOS: APNs device token converted to string
+  /// - Android: FCM token from `FirebaseMessaging.instance.getToken()`
+  /// - iOS: **APNs device token** (hex string) from
+  ///   `FirebaseMessaging.instance.getAPNSToken()`. The Zendesk iOS SDK
+  ///   requires the native APNs token, not the FCM token.
+  ///
+  /// **Important (iOS):** You must pass the APNs device token, not the FCM
+  /// registration token. FCM tokens are not compatible with the Zendesk iOS
+  /// SDK's push notification system. Use `getAPNSToken()` instead of
+  /// `getToken()` on iOS.
   ///
   /// Throws [ArgumentError] if token is empty.
   /// Throws [PlatformException] if the update fails.
   ///
   /// Example:
   /// ```dart
-  /// // Android with firebase_messaging
-  /// final fcmToken = await FirebaseMessaging.instance.getToken();
-  /// if (fcmToken != null) {
-  ///   await ZendeskMessaging.updatePushNotificationToken(fcmToken);
-  /// }
+  /// import 'dart:io' show Platform;
   ///
-  /// // Listen for token refresh
-  /// FirebaseMessaging.instance.onTokenRefresh.listen((token) {
-  ///   ZendeskMessaging.updatePushNotificationToken(token);
-  /// });
+  /// // Get the correct token per platform
+  /// final messaging = FirebaseMessaging.instance;
+  /// String? token;
+  /// if (Platform.isAndroid) {
+  ///   token = await messaging.getToken();
+  /// } else if (Platform.isIOS) {
+  ///   // iOS requires the APNs token, not the FCM token
+  ///   final apnsToken = await messaging.getAPNSToken();
+  ///   token = apnsToken;
+  /// }
+  /// if (token != null) {
+  ///   await ZendeskMessaging.updatePushNotificationToken(token);
+  /// }
   /// ```
   static Future<void> updatePushNotificationToken(String token) async {
     if (token.isEmpty) {


### PR DESCRIPTION
## Summary

The push notification examples instruct developers to register the FCM token
from `getToken()` on **both** platforms. The Zendesk iOS SDK requires the
native **APNs device token**, so passing the FCM token on iOS silently fails
to deliver push — this is the exact confusion reported in #95.

The code fix landed in #101 (merged). This PR fixes the **documentation**, so
the examples stop teaching the wrong iOS usage:

- Split token retrieval per platform — `getAPNSToken()` on iOS, `getToken()`
  on Android.
- Guard `onTokenRefresh` to Android (iOS APNs tokens rarely change and are
  re-fetched on launch; `onTokenRefresh` returns FCM tokens, unusable on iOS).
- Add an **Important (iOS)** callout.
- Update the `updatePushNotificationToken` API doc comment to match.

Applied consistently across **all seven READMEs** (en, zh-TW, zh-CN, es,
pt-BR, ja, ko).

## Relationship to #96

#96 (now closed) proposed the same doc fix for the English README + Dart doc.
This PR reuses that approach (credit to @chyiiiiiiiiiiii) and additionally
covers the six translated READMEs, which #96 did not touch.

## Notes for reviewers

- Docs-only; no code changes.
- The English `README.md` + Dart doc changes match #96's wording.
- The translated callouts/comments (ja, ko, es, pt-BR) were translated to
  match; a native-speaker glance is welcome.

## Test plan

- [x] All seven READMEs use `getAPNSToken()` on iOS, `getToken()` on Android
- [x] Each README's push example imports `dart:io` for `Platform`
- [x] No README still registers `getToken()` for both platforms