### PR TITLE
docs: note showConversation should be called once per navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   token on iOS silently fails to deliver push. Token retrieval is now split per
   platform, and `onTokenRefresh` is guarded to Android (iOS APNs tokens are
   re-fetched on launch).
+- Document that `showConversation` should be called once per navigation. Rapid
+  duplicate calls can make the underlying SDK open the default conversation
+  instead of the requested one, so callers that may fire more than once for a
+  single user action (e.g. a notification tap reaching multiple handlers) should
+  de-duplicate.
 
 ## 3.2.2
 

--- a/lib/src/zendesk_messaging.dart
+++ b/lib/src/zendesk_messaging.dart
@@ -210,6 +210,12 @@ class ZendeskMessaging {
   ///
   /// Requires multi-conversations to be enabled in Zendesk Admin Center.
   ///
+  /// Call this once per navigation. Invoking it (or another messaging
+  /// navigation method) again in quick succession can cause the underlying SDK
+  /// to open the default conversation instead of [conversationId]. If a single
+  /// user action might trigger multiple calls — e.g. a notification tap handled
+  /// by more than one listener — de-duplicate before calling.
+  ///
   /// Throws [ArgumentError] if conversationId is empty.
   /// Throws [PlatformException] if the conversation cannot be shown.
   static Future<void> showConversation(String conversationId) async {


### PR DESCRIPTION
## What

Adds a documentation note (API dartdoc + CHANGELOG) for `showConversation`: it should be called **once per navigation**.

## Why

Calling `showConversation` (or another messaging navigation method) again in quick succession can cause the underlying SDK to open the **default** conversation instead of the requested `conversationId`. This is easy to hit when a single user action reaches the API through more than one path — e.g. a notification tap delivered to multiple handlers — and the symptom ("deep link always opens the first conversation") is non-obvious. Documenting the single-call expectation, and that callers should de-duplicate, saves others the debugging.

Docs-only; no behavior change.